### PR TITLE
[feat] Add Flow 전역 관리 구조 및 Coordinator 패턴 구현

### DIFF
--- a/Logit/Logit/AppState.swift
+++ b/Logit/Logit/AppState.swift
@@ -93,7 +93,7 @@ class AppState: ObservableObject {
         appPhase = .login
     }
     
-    func stardAddFlow() {
+    func startAddFlow() {
         isShowingAddFlow = true
     }
 }

--- a/Logit/Logit/AppState.swift
+++ b/Logit/Logit/AppState.swift
@@ -11,6 +11,7 @@ import SwiftUI
 class AppState: ObservableObject {
     @Published var appPhase: AppPhase = .splash
     @Published var isShowingSignUpSheet: Bool = false
+    @Published var isShowingAddFlow: Bool = false
     
     enum AppPhase {
         case splash
@@ -90,5 +91,9 @@ class AppState: ObservableObject {
         mockAccessToken = nil
         mockIsRegistrationComplete = false
         appPhase = .login
+    }
+    
+    func stardAddFlow() {
+        isShowingAddFlow = true
     }
 }

--- a/Logit/Logit/Features/AddFlowCoordinator.swift
+++ b/Logit/Logit/Features/AddFlowCoordinator.swift
@@ -7,4 +7,38 @@
 
 import SwiftUI
 
-
+struct AddFlowCoordinator: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var viewModel = AddFlowViewModel()
+    
+    var body: some View {
+        NavigationStack(path: $viewModel.path) {
+            VStack(spacing: 20) {
+                Text("Add Flow 시작!")
+                    .font(.title)
+                
+                Button("지원정보 입력으로") {
+                    viewModel.navigateToApplicationInfo()
+                }
+                
+                Button("취소") {
+                    dismiss()
+                }
+            }
+            .navigationDestination(for: AddFlowRoute.self) { route in
+                viewModel.destination(for: route)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .environmentObject(viewModel)
+        .presentationDetents([.large])
+        .presentationDragIndicator(.hidden)
+    }
+}

--- a/Logit/Logit/Features/AddFlowCoordinator.swift
+++ b/Logit/Logit/Features/AddFlowCoordinator.swift
@@ -13,29 +13,19 @@ struct AddFlowCoordinator: View {
     
     var body: some View {
         NavigationStack(path: $viewModel.path) {
-            VStack(spacing: 20) {
-                Text("Add Flow 시작!")
-                    .font(.title)
-                
-                Button("지원정보 입력으로") {
-                    viewModel.navigateToApplicationInfo()
+            
+            ApplicationInfoView()
+                .navigationDestination(for: AddFlowRoute.self) { route in
+                    viewModel.destination(for: route)
                 }
-                
-                Button("취소") {
-                    dismiss()
-                }
-            }
-            .navigationDestination(for: AddFlowRoute.self) { route in
-                viewModel.destination(for: route)
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("취소") {
-                        dismiss()
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") {
+                            dismiss()
+                        }
                     }
                 }
-            }
         }
         .environmentObject(viewModel)
         .presentationDetents([.large])

--- a/Logit/Logit/Features/AddFlowCoordinator.swift
+++ b/Logit/Logit/Features/AddFlowCoordinator.swift
@@ -1,0 +1,10 @@
+//
+//  AddFlowCoordinator.swift
+//  Logit
+//
+//  Created by 임재현 on 1/26/26.
+//
+
+import SwiftUI
+
+

--- a/Logit/Logit/Features/AddFlowRoute.swift
+++ b/Logit/Logit/Features/AddFlowRoute.swift
@@ -1,0 +1,14 @@
+//
+//  AddFlowRoute.swift
+//  Logit
+//
+//  Created by 임재현 on 1/26/26.
+//
+
+import Foundation
+
+enum AddFlowRoute: Hashable {
+    case applicationInfo // 지원 정보 입력
+    case coverLetterQuestions // 자소서 문항
+    case questionDetails(String) // 상세문항 (q1,q2...)
+}

--- a/Logit/Logit/Features/AddFlowViewModel.swift
+++ b/Logit/Logit/Features/AddFlowViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  AddFlowViewModel.swift
+//  Logit
+//
+//  Created by 임재현 on 1/26/26.
+//
+
+import SwiftUI
+
+@MainActor
+class AddFlowViewModel: ObservableObject {
+    @Published var path = NavigationPath()
+    
+    // Navigation 함수들
+    func navigateToApplicationInfo() {
+        path.append(AddFlowRoute.applicationInfo)
+    }
+    
+    func navigateToQuestions() {
+        path.append(AddFlowRoute.coverLetterQuestions)
+    }
+    
+    func navigateBack() {
+        if !path.isEmpty {
+            path.removeLast()
+        }
+    }
+    
+    // View 생성
+    @ViewBuilder
+    func destination(for route: AddFlowRoute) -> some View {
+        switch route {
+        case .applicationInfo:
+            // TODO: 실제 View로 교체
+            Text("지원정보 입력 화면")
+                .navigationTitle("지원 정보")
+            
+        case .coverLetterQuestions:
+            Text("자기소개서 문항 화면")
+                .navigationTitle("자기소개서 문항")
+            
+        case .questionDetails(let id):
+            Text("문항 상세: \(id)")
+                .navigationTitle("문항 작성")
+            
+
+        }
+    }
+}
+

--- a/Logit/Logit/Features/AddFlowViewModel.swift
+++ b/Logit/Logit/Features/AddFlowViewModel.swift
@@ -12,6 +12,11 @@ class AddFlowViewModel: ObservableObject {
     @Published var path = NavigationPath()
     
     // Navigation 함수들
+    
+    func navigateToCoverLetterQuestions() {
+        path.append(AddFlowRoute.coverLetterQuestions)
+    }
+    
     func navigateToApplicationInfo() {
         path.append(AddFlowRoute.applicationInfo)
     }
@@ -32,8 +37,7 @@ class AddFlowViewModel: ObservableObject {
         switch route {
         case .applicationInfo:
             // TODO: 실제 View로 교체
-            Text("지원정보 입력 화면")
-                .navigationTitle("지원 정보")
+            EmptyView()
             
         case .coverLetterQuestions:
             Text("자기소개서 문항 화면")

--- a/Logit/Logit/Features/ApplicationInfoView.swift
+++ b/Logit/Logit/Features/ApplicationInfoView.swift
@@ -1,0 +1,40 @@
+//
+//  ApplicationInfoView.swift
+//  Logit
+//
+//  Created by 임재현 on 1/26/26.
+//
+
+import SwiftUI
+
+struct ApplicationInfoView: View {
+    @EnvironmentObject var viewModel: AddFlowViewModel
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("지원 정보 입력")
+                .font(.title)
+            
+            // TODO: 실제 폼 구현
+            TextField("회사명", text: .constant(""))
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            
+            TextField("직무", text: .constant(""))
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            
+            Spacer()
+            
+            Button("다음") {
+                viewModel.navigateToCoverLetterQuestions()
+            }
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(12)
+        }
+        .padding()
+        .navigationTitle("지원 정보")
+    }
+}

--- a/Logit/Logit/Home/HomeView.swift
+++ b/Logit/Logit/Home/HomeView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct HomeView: View {
-    @State private var hasProjects: Bool = true
+    @EnvironmentObject var appState: AppState
+    @State private var hasProjects: Bool = false
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Logit/Logit/Home/ProjectListSection.swift
+++ b/Logit/Logit/Home/ProjectListSection.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ProjectListSection: View {
+    @EnvironmentObject var appState: AppState
     let hasProjects: Bool
     
     var body: some View {
@@ -34,6 +35,8 @@ struct ProjectListSection: View {
 }
 
 struct ProjectEmptyView: View {
+    @EnvironmentObject var appState: AppState
+    
     var body: some View {
         VStack(spacing: 0) {
             Image("app_status_empty2")
@@ -47,7 +50,7 @@ struct ProjectEmptyView: View {
                 .padding(.top, 16.adjustedLayout)
             
             Button {
-                // 버튼 액션
+                appState.startAddFlow()
             } label: {
                 Text("자기소개서 작성")
                     .typo(.body6_medium)

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -46,9 +46,8 @@ struct MainTabView: View {
             }
         }
         .ignoresSafeArea(.keyboard)
-        .sheet(isPresented: $appState.isShowingAddFlow) {
+        .fullScreenCover(isPresented: $appState.isShowingAddFlow) {
             AddFlowCoordinator()
-                .presentationDetents([.large])
         }
     }
 }

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @EnvironmentObject var appState: AppState
     @State private var selectedTab: Tab = .home
     
     enum Tab {
@@ -26,7 +27,7 @@ struct MainTabView: View {
                     case .search:
                         Text("검색")
                     case .add:
-                        Text("추가")
+                        EmptyView()
                     case .activity:
                         Text("경험")
                     case .profile:
@@ -39,15 +40,22 @@ struct MainTabView: View {
             // Custom TabBar
             VStack {
                 Spacer()
-                CustomTabBar(selectedTab: $selectedTab)
+                CustomTabBar(selectedTab: $selectedTab) {
+                    appState.startAddFlow()
+                }
             }
         }
         .ignoresSafeArea(.keyboard)
+        .sheet(isPresented: $appState.isShowingAddFlow) {
+            Text("Add Flow 시작!")
+                .presentationDetents([.large])
+        }
     }
 }
 
 struct CustomTabBar: View {
     @Binding var selectedTab: MainTabView.Tab
+    let onAddTapped: () -> Void
     
     var body: some View {
         HStack(spacing: 0) {
@@ -72,7 +80,7 @@ struct CustomTabBar: View {
                 title: "추가",
                 isSelected: selectedTab == .add
             ) {
-                selectedTab = .add
+                onAddTapped()
             }
             
             TabBarItem(

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -47,7 +47,7 @@ struct MainTabView: View {
         }
         .ignoresSafeArea(.keyboard)
         .sheet(isPresented: $appState.isShowingAddFlow) {
-            Text("Add Flow 시작!")
+            AddFlowCoordinator()
                 .presentationDetents([.large])
         }
     }


### PR DESCRIPTION
## 🎫 What is the PR?

Add Flow를 전역 상태로 관리하여 앱 내 어디서든 자기소개서 작성 플로우를 시작할 수 있도록 구조를 구축했습니다. Coordinator 패턴을 도입하여 독립적인 Navigation 관리, 깊은 플로우의 체계적인 상태 공유, 그리고 향후 딥링크 등의 진입점 추가 시에도 유연하게 대응할 수 있는 확장 가능한 구조를 제공합니다.

## 🎫 Changes

- AppState에 Add Flow 전역 상태 관리 추가 (`isShowingAddFlow`, `startAddFlow()`)
- MainTabView에 fullScreenCover로 Add Flow 연결
- CustomTabBar Add 버튼에 콜백 방식 적용
- AddFlowRoute enum 정의 (applicationInfo, coverLetterQuestions, questionDetail, preview, complete)
- AddFlowCoordinator(View) + AddFlowViewModel(ObservableObject) 구조 생성
- HomeView의 ProjectEmptyView에서 Add Flow 접근 구현
- NavigationStack 기반 독립적인 Add Flow Navigation 구조 완성

## 🎫 Thoughts

### 1. 왜 Coordinator 패턴인가?

**문제 인식:**
- Add Flow는 지원정보 입력 → 자기소개서 문항 → 상세 작성 → 미리보기(경험 등록 등) → 완료까지 깊은 depth를 가짐
- 여러 탭(Home, MainTab 등)에서 동일한 Flow에 접근해야 함
- 각 탭의 Navigation과 Add Flow의 Navigation이 충돌하면 안 됨

**해결 방안:**
- Add Flow를 완전히 독립적인 NavigationStack으로 분리
- 전역 Sheet(fullScreenCover)로 관리하여 어디서든 접근 가능
- Coordinator를 통해 Flow의 모든 상태와 전환 로직을 한 곳에서 관리

### 2. Coordinator = View vs ObservableObject?

**고민:**
- 전통적인 Coordinator 패턴은 ObservableObject를 사용
- 하지만 SwiftUI는 NavigationStack을 View 레벨에서 관리해야 함

**선택:**
```swift
struct AddFlowCoordinator: View {  // View로 정의
    @StateObject private var viewModel = AddFlowViewModel()  // 실제 로직은 ViewModel
}
```

**이유:**
- SwiftUI의 선언적 특성에 더 자연스러움
- Sheet의 content는 반드시 View여야 함
- NavigationStack을 View body에서 직접 관리 가능
- ViewModel은 순수하게 상태와 비즈니스 로직만 담당

### 3. Sheet vs FullScreenCover?

**고민:**
- Sheet: 드래그로 닫기 가능, 뒤 배경 보임, 가벼운 느낌
- FullScreenCover: 전체 화면, 몰입도 높음, 의도적인 닫기 필요

**선택:** FullScreenCover

**이유:**
- Add Flow는 여러 단계를 거치는 중요한 작업 흐름
- 실수로 드래그해서 닫히면 작성 중인 데이터 손실 위험
- 전체 화면으로 몰입감 있는 작성 경험 제공
- Instagram, 카카오톡 등 메이저 앱들도 게시물 작성 시 fullScreenCover 사용

### 4. 전역 상태 관리 위치

**고민:**
- MainTabView에서 직접 관리? vs AppState에서 관리?

**선택:** AppState에서 관리

**이유:**
- 여러 탭에서 접근해야 하므로 더 상위 레벨 필요
- 향후 딥링크, 푸시 알림 등에서도 Add Flow 시작 가능
- 단일 진실 공급원(Single Source of Truth) 원칙
- 테스트 시 AppState만 모킹하면 전체 Flow 테스트 가능

### 5. EnvironmentObject 전파
```swift
MainTabView
    .environmentObject(appState)  // 여기서 주입
        ↓
HomeView (자동 전달)
    ↓
ProjectListSection (자동 전달)
    ↓
ProjectEmptyView (자동 전달)
    Button { appState.startAddFlow() }  // 바로 접근 가능
```

**장점:**
- Props drilling 없이 깊은 컴포넌트에서 바로 접근
- 코드가 간결하고 유지보수 용이
- 새로운 Empty State 추가 시 간단하게 연결 가능

### 6. Route 설계
```swift
enum AddFlowRoute: Hashable {
    case applicationInfo
    case coverLetterQuestions
    case questionDetail(String)  // Associated Value로 데이터 전달
    case preview
    case complete
}
```

**고려사항:**
- Hashable 채택으로 NavigationPath에서 사용 가능
- Associated Value로 화면 간 데이터 전달
- 향후 확장 가능한 구조 (예: .questionDetail(Question) 객체로 변경 가능)


## 🎫 Screenshot

|    Home Empty에서 접근    |   MainTab에서 접근   |
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/34dfde73-5116-4a48-affa-42bb4da7909c" width ="250"> | <img src = "https://github.com/user-attachments/assets/e5c6689f-703f-4694-b1fc-329693536cd1" width ="250"> |



## 🎫 To Reviewers

- **AppState의 역할 확장**: Add Flow 상태 관리가 AppState에 추가되었는데, 이 위치가 적절할 것이지 생각해봐야함
- **Coordinator 네이밍**: `AddFlowCoordinator`가 View임에도 "Coordinator"라는 이름이 혼란스럽지 않은지 생각해봐야함 (대안: `AddFlowContainer`, `AddFlowRootView`)
- **ViewModel 책임 범위**: 현재 ViewModel이 Navigation 로직과 상태 관리를 모두 담당하는데, 추후 분리 필요성이 있을지 검토 해봐야 할듯 
- **에러 처리**: 현재는 기본 구조만 잡았고, 작성 중 취소 시 Alert 등의 UX는 다음 PR에서 추가 예정

## 🖥️ 주요 코드 설명

### `AppState`
- Add Flow의 전역 상태 관리
- `isShowingAddFlow`: fullScreenCover의 표시 여부
- `startAddFlow()`: 어디서든 Add Flow를 시작할 수 있는 진입점
```swift
@MainActor
class AppState: ObservableObject {
    @Published var appPhase: AppPhase = .splash
    @Published var isShowingSignUpSheet: Bool = false
    @Published var isShowingAddFlow: Bool = false  //  추가
    
    // Add Flow 시작 함수
    func startAddFlow() {
        isShowingAddFlow = true
    }
}
```

### `MainTabView`
- fullScreenCover로 Add Flow 전체 화면 표시
- appState를 environmentObject로 주입하여 하위 View에서 접근 가능
```swift
struct MainTabView: View {
    @EnvironmentObject var appState: AppState
    @State private var selectedTab: Tab = .home
    
    var body: some View {
        ZStack {
            // 탭 컨텐츠...
        }
        .fullScreenCover(isPresented: $appState.isShowingAddFlow) {
            AddFlowCoordinator()
        }
    }
}
```

### `CustomTabBar`
- Add 버튼만 특수 처리
- 탭 선택이 아닌 콜백 호출로 Sheet 트리거
```swift
struct CustomTabBar: View {
    @Binding var selectedTab: MainTabView.Tab
    let onAddTapped: () -> Void  // 콜백 추가
    
    var body: some View {
        HStack(spacing: 0) {
            // ...
            TabBarItem(
                icon: selectedTab == .add ? "plus_selected" : "plus",
                title: "추가",
                isSelected: selectedTab == .add
            ) {
                onAddTapped()  //  탭 변경 대신 콜백 호출
            }
            // ...
        }
    }
}
```

### `AddFlowRoute`
- Add Flow의 모든 화면을 enum으로 정의
- Hashable 채택으로 NavigationPath에서 사용
- Associated Value로 화면 간 데이터 전달
```swift
enum AddFlowRoute: Hashable {
    case applicationInfo        // 지원정보 입력
    case coverLetterQuestions   // 자기소개서 문항
    case questionDetail(String) // 문항 상세 입력
    case preview               // 미리보기
    case complete              // 완료
}
```

### `AddFlowCoordinator`
- Add Flow의 컨테이너 역할
- NavigationStack으로 독립적인 Navigation 관리
- ViewModel을 environmentObject로 하위 View에 전달
```swift
struct AddFlowCoordinator: View {
    @Environment(\.dismiss) var dismiss
    @StateObject private var viewModel = AddFlowViewModel()
    
    var body: some View {
        NavigationStack(path: $viewModel.path) {
            // 시작 화면
            VStack {
                // 임시 UI
            }
            .navigationDestination(for: AddFlowRoute.self) { route in
                viewModel.destination(for: route)
            }
            .toolbar {
                ToolbarItem(placement: .cancellationAction) {
                    Button("취소") {
                        dismiss()
                    }
                }
            }
        }
        .environmentObject(viewModel)
    }
}
```

### `AddFlowViewModel`
- Add Flow의 모든 상태와 Navigation 로직 관리
- `path`: NavigationPath로 화면 스택 관리
- `destination(for:)`: Route에 따른 View 생성
```swift
@MainActor
class AddFlowViewModel: ObservableObject {
    @Published var path = NavigationPath()
    
    // Navigation 함수들
    func navigateToApplicationInfo() {
        path.append(AddFlowRoute.applicationInfo)
    }
    
    func navigateToQuestions() {
        path.append(AddFlowRoute.coverLetterQuestions)
    }
    
    func navigateBack() {
        if !path.isEmpty {
            path.removeLast()
        }
    }
    
    // View 생성 (Router 역할)
    @ViewBuilder
    func destination(for route: AddFlowRoute) -> some View {
        switch route {
        case .applicationInfo:
            Text("지원정보 입력 화면")
                .navigationTitle("지원 정보")
        case .coverLetterQuestions:
            Text("자기소개서 문항 화면")
                .navigationTitle("자기소개서 문항")
        // ... 나머지 Route 처리
        }
    }
}
```

### `ProjectEmptyView`
- Home 탭에서 프로젝트가 없을 때 표시
- environmentObject로 appState에 접근
- 버튼 클릭 시 Add Flow 시작
```swift
struct ProjectEmptyView: View {
    @EnvironmentObject var appState: AppState  //  전역 상태 접근
    
    var body: some View {
        VStack(spacing: 0) {
            Image("app_status_empty2")
            Text("자기소개서를 생성해보세요")
            
            Button {
                appState.startAddFlow()  // Add Flow 시작
            } label: {
                Text("자기소개서 작성")
            }
        }
    }
}
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues

- Resolved: #이슈번호