### PR TITLE
[feat] 설정 화면 UI 구현 및 홈 헤더에서 설정 진입 기능 추가

### DIFF
--- a/Logit/Logit/AppState.swift
+++ b/Logit/Logit/AppState.swift
@@ -12,6 +12,7 @@ class AppState: ObservableObject {
     @Published var appPhase: AppPhase = .splash
     @Published var isShowingSignUpSheet: Bool = false
     @Published var isShowingAddFlow: Bool = false
+    @Published var isShowingSettings = false
     
     enum AppPhase {
         case splash
@@ -95,5 +96,9 @@ class AppState: ObservableObject {
     
     func startAddFlow() {
         isShowingAddFlow = true
+    }
+    
+    func startSettings() {
+        isShowingSettings = true
     }
 }

--- a/Logit/Logit/Features/SettingsView.swift
+++ b/Logit/Logit/Features/SettingsView.swift
@@ -1,0 +1,14 @@
+//
+//  SettingsView.swift
+//  Logit
+//
+//  Created by 임재현 on 1/29/26.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}

--- a/Logit/Logit/Features/SettingsView.swift
+++ b/Logit/Logit/Features/SettingsView.swift
@@ -8,7 +8,127 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var isNotificationEnabled: Bool = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: 0) {
+            CustomNavigationBar(
+                title: "설정",
+                showBackButton: true,
+                onBackTapped: { dismiss() }
+            )
+            
+            // 프로필 영역
+            HStack(spacing: 20) {
+                // 프로필 이미지
+                Circle()
+                    .fill(Color.primary50)
+                    .frame(width: 48, height: 48)
+                
+                // 닉네임
+                Text("로짓")
+                    .typo(.bold_20)
+                    .foregroundColor(.gray400)
+                
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            
+            // 구분선
+            Rectangle()
+                .fill(Color.gray100)
+                .frame(height: 2)
+                .padding(.top, 26)
+            
+            // 알림 설정
+            HStack {
+                Text("알림 설정")
+                    .typo(.semibold_16)
+                    .foregroundColor(.black)
+                
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 30)
+            
+            HStack {
+                Text("커리어 리포트 업데이트 알림")
+                    .typo(.regular_14_140)
+                    .foregroundColor(.gray400)
+                
+                Spacer()
+                
+                Toggle("", isOn: $isNotificationEnabled)
+                    .labelsHidden()
+                    .scaleEffect(0.8)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 28)
+            
+            // 구분선
+            Rectangle()
+                .fill(Color.gray100)
+                .frame(height: 2)
+                .padding(.top, 34)
+            
+            // 다음 섹션 타이틀
+            HStack {
+                Text("고객 지원 및 정보")
+                    .typo(.semibold_16)
+                    .foregroundColor(.black)
+                
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 30)
+            
+            VStack(spacing: 0) {
+                SettingsRow(title: "문의하기") {
+                    print("문의하기 클릭")
+                }
+                
+                SettingsRow(title: "로그아웃") {
+                    print("로그아웃 클릭")
+                }
+                
+                SettingsRow(title: "회원탈퇴") {
+                    print("회원탈퇴 클릭")
+                }
+            }
+            .padding(.top, 14)
+            
+            Spacer()
+        }
+    }
+}
+
+
+
+struct SettingsRow: View {
+    let title: String
+    let action: () -> Void
+    
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            HStack {
+                Text(title)
+                    .typo(.regular_14_140)
+                    .foregroundColor(.gray400)
+                
+                Spacer()
+                
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray300)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
     }
 }

--- a/Logit/Logit/Home/HomeHeaderView.swift
+++ b/Logit/Logit/Home/HomeHeaderView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct HomeHeaderView: View {
+    @EnvironmentObject var appState: AppState
+    
     var body: some View {
         HStack {
            Image("app_logo_symbolWord")
@@ -21,6 +23,9 @@ struct HomeHeaderView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(size: 35.2.adjustedLayout)
+                .onTapGesture {
+                    appState.startSettings()
+                }
         }
         .padding(.vertical, 8.adjustedLayout)
         .padding(.horizontal, 20.adjustedLayout)

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -49,6 +49,9 @@ struct MainTabView: View {
         .fullScreenCover(isPresented: $appState.isShowingAddFlow) {
             AddFlowCoordinator()
         }
+        .fullScreenCover(isPresented: $appState.isShowingSettings) {
+            SettingsView()
+        }
     }
 }
 


### PR DESCRIPTION
## 🎫 What is the PR?
설정 화면 UI 구현 및 홈 헤더에서 설정 진입 기능 추가

## 🎫 Changes
- SettingsView UI 구현 (프로필, 알림 설정, 고객 지원 메뉴)
- SettingsRow 재사용 가능한 컴포넌트 구현
- AppState에 설정 화면 상태 관리 추가
- HomeHeaderView에 설정 진입 버튼 연동
- MainTabView에 설정 화면 FullScreenCover 추가
- 알림 설정 Toggle 구현
- 고객 지원 메뉴 리스트 구현 (문의하기, 로그아웃, 회원탈퇴)

## 🎫 Thoughts
**1. 설정 화면 진입 방식 선택**
- NavigationStack Push vs Sheet vs FullScreenCover 중 선택
- FullScreenCover 채택: AddFlowCoordinator와 동일한 패턴으로 일관성 유지
- 설정 화면의 특성상 전체 화면으로 표시하는 것이 iOS 네이티브 앱과 유사

**2. AppState를 통한 전역 상태 관리**
- HomeHeaderView뿐만 아니라 프로필 탭 등 다른 곳에서도 설정을 열 가능성 고려
- AddFlow와 동일하게 AppState에서 중앙 관리
- `startSettings()` 메서드로 일관된 진입점 제공

**3. 재사용 가능한 컴포넌트 설계**
- SettingsRow를 독립적인 컴포넌트로 분리
- 타이틀과 액션만 전달하면 되는 간단한 인터페이스
- 향후 메뉴 추가 시 쉽게 확장 가능

**4. Toggle 크기 조정**
- SwiftUI 기본 Toggle은 크기 커스터마이징 제한적
- scaleEffect를 활용한 비율 조정으로 해결
- 정확한 픽셀 단위 조정보다는 전체적인 밸런스 우선

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "https://github.com/user-attachments/assets/d035c2e8-1e0f-461f-bd6e-6e56acc5c42d" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers

## 🖥️ 주요 코드 설명

`AppState`
- 설정 화면 표시 상태 관리 추가
- startSettings() 메서드로 설정 진입점 제공
```swift
@Published var isShowingSettings = false

func startSettings() {
    isShowingSettings = true
}
```

`MainTabView`
- FullScreenCover로 설정 화면 표시
- AddFlowCoordinator와 동일한 패턴
```swift
.fullScreenCover(isPresented: $appState.isShowingSettings) {
    SettingsView()
}
```

`HomeHeaderView`
- AppState 주입 및 설정 버튼 연동
```swift
@EnvironmentObject var appState: AppState

Image("app_user")
    .onTapGesture {
        appState.startSettings()
    }
```

`SettingsView`
- 프로필, 알림 설정, 고객 지원 메뉴로 구성된 설정 화면
- CustomNavigationBar로 뒤로가기 제공
```swift
VStack(spacing: 0) {
    CustomNavigationBar(
        title: "설정",
        showBackButton: true,
        onBackTapped: { dismiss() }
    )
    
    // 프로필 영역
    HStack(spacing: 20) {
        Circle()
            .fill(Color.primary50)
            .frame(width: 48, height: 48)
        
        Text("닉네임")
            .typo(.bold_20)
            .foregroundColor(.gray400)
        
        Spacer()
    }
    .padding(.horizontal, 20)
    .padding(.top, 20)
    
    // 알림 설정 Toggle
    Toggle("", isOn: $isNotificationEnabled)
        .scaleEffect(0.8)
}
```

`SettingsRow`
- 재사용 가능한 설정 메뉴 Row 컴포넌트
- 타이틀과 액션을 받아 일관된 UI 제공
```swift
struct SettingsRow: View {
    let title: String
    let action: () -> Void
    
    var body: some View {
        Button {
            action()
        } label: {
            HStack {
                Text(title)
                    .typo(.regular_14_140)
                    .foregroundColor(.gray400)
                
                Spacer()
                
                Image(systemName: "chevron.right")
                    .font(.system(size: 14))
                    .foregroundColor(.gray300)
            }
            .padding(.horizontal, 20)
            .padding(.vertical, 14)
        }
        .buttonStyle(PlainButtonStyle())
    }
}

// 사용 예시
VStack(spacing: 0) {
    SettingsRow(title: "문의하기") {
        print("문의하기 클릭")
    }
    
    SettingsRow(title: "로그아웃") {
        print("로그아웃 클릭")
    }
    
    SettingsRow(title: "회원탈퇴") {
        print("회원탈퇴 클릭")
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #15 