### PR TITLE
[feat] Clean Architecture 기반 Network Layer 구현 (Protocol, Error Handling, Token Interceptor)

### DIFF
--- a/Logit/Logit/Network/Core/APIEndpoint.swift
+++ b/Logit/Logit/Network/Core/APIEndpoint.swift
@@ -1,0 +1,46 @@
+//
+//  APIEndpoint.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import UIKit
+
+enum APIEndpoint {
+    // Auth
+    case googleLogin // 구글 로그인
+    case googleCallback // 구글 콜백
+    case refreshToken //  엑세스토큰 갱신
+    case logout // 로그아웃
+    
+    var path: String {
+        switch self {
+        case .googleLogin:
+            return "/api/v1/auth/google"
+        case .googleCallback:
+            return "/api/v1/auth/google/callback"
+        case .refreshToken:
+            return "/api/v1/auth/refresh"
+        case .logout:
+            return "/api/v1/auth/logout"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .googleLogin, .googleCallback:
+            return .get
+        case .refreshToken, .logout:
+            return .post
+        }
+    }
+}
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/Logit/Logit/Network/Core/APIError.swift
+++ b/Logit/Logit/Network/Core/APIError.swift
@@ -1,0 +1,106 @@
+//
+//  APIError.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+enum APIError {
+    case invalidURL
+    case invalidResponse
+    case badRequest(message: String) // 400
+    case unauthorized(message: String)  // 401
+    case forbidden(message: String) // 403
+    case notFound(message: String)  // 404
+    case validationError(errors: [ValidationError]) // 422
+    case serverError(message: String) // 500
+    case networkError(Error)
+    case decodingError(Error)
+    case unknown(statusCode: Int, message: String?)
+    
+    var localizedDescription: String {
+        switch self {
+        case .invalidURL:
+            return "잘못된 URL입니다."
+        case .invalidResponse:
+            return "잘못된 응답입니다."
+        case .badRequest(let message):
+            return message
+        case .unauthorized(let message):
+            return message
+        case .forbidden(let message):
+            return message
+        case .notFound(let message):
+            return message
+        case .validationError(let errors):
+            return errors.map { $0.message }.joined(separator: "\n")
+        case .serverError(let message):
+            return message
+        case .networkError(let error):
+            return "네트워크 오류: \(error.localizedDescription)"
+        case .decodingError(let error):
+            return "데이터 파싱 오류: \(error.localizedDescription)"
+        case .unknown(let statusCode, let message):
+            if let message = message {
+                return "알 수 없는 오류 (코드: \(statusCode)): \(message)"
+            } else {
+                return "알 수 없는 오류 (코드: \(statusCode))"
+            }
+        }
+    }
+    
+}
+
+struct ErrorResponse: Decodable {
+    let detail: DetailType
+    
+    enum DetailType: Decodable {
+        case string(String)
+        case validationErrors([ValidationErrorDetail])
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            
+            // String으로 파싱 시도
+            if let stringValue = try? container.decode(String.self) {
+                self = .string(stringValue)
+                return
+            }
+            
+            // ValidationError 배열로 파싱 시도
+            if let arrayValue = try? container.decode([ValidationErrorDetail].self) {
+                self = .validationErrors(arrayValue)
+                return
+            }
+            
+            throw DecodingError.typeMismatch(
+                DetailType.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected String or [ValidationErrorDetail]"
+                )
+            )
+        }
+    }
+}
+
+struct ValidationErrorDetail: Decodable {
+    let loc: [String]
+    let msg: String
+    let type: String
+}
+
+struct ValidationError {
+    let field: String
+    let message: String
+    let type: String
+    
+    init(from detail: ValidationErrorDetail) {
+        // loc에서 필드명 추출 (예: ["body", "email"] -> "email")
+        self.field = detail.loc.last ?? "unknown"
+        self.message = detail.msg
+        self.type = detail.type
+    }
+}

--- a/Logit/Logit/Network/Core/APIError.swift
+++ b/Logit/Logit/Network/Core/APIError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum APIError {
+enum APIError: Error {
     case invalidURL
     case invalidResponse
     case badRequest(message: String) // 400

--- a/Logit/Logit/Network/Core/DefaultNetworkClient.swift
+++ b/Logit/Logit/Network/Core/DefaultNetworkClient.swift
@@ -1,0 +1,209 @@
+//
+//  DefaultNetworkClient.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+class DefaultNetworkClient: NetworkClient {
+    private let baseURL: String
+    private let tokenManager: TokenManager
+    private var refreshTask: Task<Void, Error>?
+    
+    init(
+        baseURL: String = "https://api.example.com",
+        tokenManager: TokenManager = .shared
+    ) {
+        self.baseURL = baseURL
+        self.tokenManager = tokenManager
+    }
+    
+    
+    func request<T: Decodable>(
+        endpoint: APIEndpoint,
+        body: Encodable? = nil
+    ) async throws -> T {
+        let data = try await performRequest(endpoint: endpoint, body: body)
+        
+        do {
+            let decoded = try JSONDecoder().decode(T.self, from: data)
+            return decoded
+        } catch {
+            throw APIError.decodingError(error)
+        }
+    }
+    
+    func request(
+        endpoint: APIEndpoint,
+        body: Encodable? = nil
+    ) async throws {
+        _ = try await performRequest(endpoint: endpoint, body: body)
+    }
+    
+    
+    private func performRequest(
+        endpoint: APIEndpoint,
+        body: Encodable?,
+        isRetry: Bool = false
+    ) async throws -> Data {
+        // 1. URLRequest 생성
+        var request = try createURLRequest(endpoint: endpoint, body: body)
+        
+        // 2. 토큰 추가
+        if let accessToken = tokenManager.accessToken {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        }
+        
+        // 3. 요청 실행
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        // 4. 응답 검증
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        
+        // 5. 상태 코드 처리
+        switch httpResponse.statusCode {
+        case 200...299:
+            return data
+            
+        case 400:
+            let error = try parseErrorResponse(from: data)
+            throw APIError.badRequest(message: error)
+            
+        case 401:
+            // 토큰 만료 - 재시도 1회만
+            if !isRetry {
+                try await refreshAccessToken()
+                return try await performRequest(endpoint: endpoint, body: body, isRetry: true)
+            } else {
+                let error = try parseErrorResponse(from: data)
+                throw APIError.unauthorized(message: error)
+            }
+            
+        case 403:
+            let error = try parseErrorResponse(from: data)
+            throw APIError.forbidden(message: error)
+            
+        case 404:
+            let error = try parseErrorResponse(from: data)
+            throw APIError.notFound(message: error)
+            
+        case 422:
+            let validationErrors = try parseValidationErrors(from: data)
+            throw APIError.validationError(errors: validationErrors)
+            
+        case 500...599:
+            let error = try? parseErrorResponse(from: data)
+            throw APIError.serverError(message: error ?? "서버 오류가 발생했습니다.")
+            
+        default:
+            let error = try? parseErrorResponse(from: data)
+            throw APIError.unknown(statusCode: httpResponse.statusCode, message: error)
+        }
+    }
+    
+    private func createURLRequest(
+        endpoint: APIEndpoint,
+        body: Encodable?
+    ) throws -> URLRequest {
+        // URL 생성
+        guard let url = URL(string: baseURL + endpoint.path) else {
+            throw APIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        // Body 추가
+        if let body = body {
+            do {
+                request.httpBody = try JSONEncoder().encode(body)
+            } catch {
+                throw APIError.networkError(error)
+            }
+        }
+        
+        return request
+    }
+    
+    private func parseErrorResponse(from data: Data) throws -> String {
+        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
+        
+        switch errorResponse.detail {
+        case .string(let message):
+            return message
+        case .validationErrors:
+            return "검증 오류가 발생했습니다."
+        }
+    }
+    
+    private func parseValidationErrors(from data: Data) throws -> [ValidationError] {
+        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
+        
+        switch errorResponse.detail {
+        case .validationErrors(let details):
+            return details.map { ValidationError(from: $0) }
+        case .string:
+            return []
+        }
+    }
+    
+    
+    private func refreshAccessToken() async throws {
+        // 이미 갱신 중이면 기다림
+        if let task = refreshTask {
+            return try await task.value
+        }
+        
+        // 갱신 작업 생성
+        let task = Task {
+            guard let refreshToken = tokenManager.refreshToken else {
+                throw APIError.unauthorized(message: "Refresh token이 없습니다.")
+            }
+            
+            // Refresh Token으로 새 Access Token 받기
+            let request = try createURLRequest(
+                endpoint: .refreshToken,
+                body: RefreshTokenRequest(refreshToken: refreshToken)
+            )
+            
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw APIError.unauthorized(message: "토큰 갱신에 실패했습니다.")
+            }
+            
+            let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+            tokenManager.updateAccessToken(tokenResponse.accessToken)
+        }
+        
+        refreshTask = task
+        
+        do {
+            try await task.value
+            refreshTask = nil
+        } catch {
+            refreshTask = nil
+            // 갱신 실패 시 토큰 클리어
+            tokenManager.clearTokens()
+            throw error
+        }
+    }
+}
+
+
+struct RefreshTokenRequest: Encodable {
+    let refreshToken: String
+}
+
+struct TokenResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String?
+}
+
+struct Empty: Encodable {}

--- a/Logit/Logit/Network/Core/KeychainManager.swift
+++ b/Logit/Logit/Network/Core/KeychainManager.swift
@@ -1,0 +1,105 @@
+//
+//  KeychainManager.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Security
+import Foundation
+
+class KeychainManager {
+    static let shared = KeychainManager()
+    private init() {}
+    
+    enum KeychainError: Error {
+        case duplicateItem
+        case unknown(OSStatus)
+        case itemNotFound
+    }
+    
+    // 저장
+    func save(key: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.unknown(errSecParam)
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        
+        if status == errSecDuplicateItem {
+            // 이미 있으면 업데이트
+            try update(key: key, value: value)
+        } else if status != errSecSuccess {
+            throw KeychainError.unknown(status)
+        }
+    }
+    
+    // 조회
+    func get(key: String) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        
+        if status == errSecItemNotFound {
+            return nil
+        }
+        
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            throw KeychainError.unknown(status)
+        }
+        
+        return value
+    }
+    
+    // 업데이트
+    private func update(key: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.unknown(errSecParam)
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+        
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        
+        guard status == errSecSuccess else {
+            throw KeychainError.unknown(status)
+        }
+    }
+    
+    // 삭제
+    func delete(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unknown(status)
+        }
+    }
+}
+

--- a/Logit/Logit/Network/Core/NetworkClient.swift
+++ b/Logit/Logit/Network/Core/NetworkClient.swift
@@ -1,0 +1,21 @@
+//
+//  NetworkClient.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+protocol NetworkClient {
+    func request<T:Decodable>(
+        endpoint: APIEndpoint,
+        body: Encodable?
+    ) async throws -> T
+    
+    // 응답 body 없을때
+    func request(
+        endpoint: APIEndpoint,
+        body: Encodable?
+    ) async throws
+}

--- a/Logit/Logit/Network/Core/TokenManager.swift
+++ b/Logit/Logit/Network/Core/TokenManager.swift
@@ -1,0 +1,71 @@
+//
+//  TokenManager.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+class TokenManager {
+    static let shared = TokenManager()
+    private let keychain = KeychainManager.shared
+    
+    private let accessTokenKey = "accessToken"
+    private let refreshTokenKey = "refreshToken"
+    
+    // 메모리 캐시 (매번 Keychain 접근 방지)
+    private var _accessToken: String?
+    private var _refreshToken: String?
+    
+    var accessToken: String? {
+        if let token = _accessToken {
+            return token
+        }
+        _accessToken = try? keychain.get(key: accessTokenKey)
+        return _accessToken
+    }
+    
+    var refreshToken: String? {
+        if let token = _refreshToken {
+            return token
+        }
+        _refreshToken = try? keychain.get(key: refreshTokenKey)
+        return _refreshToken
+    }
+    
+    func saveTokens(access: String, refresh: String) {
+        do {
+            try keychain.save(key: accessTokenKey, value: access)
+            try keychain.save(key: refreshTokenKey, value: refresh)
+            _accessToken = access
+            _refreshToken = refresh
+        } catch {
+            print("Keychain save error: \(error)")
+        }
+    }
+    
+    func updateAccessToken(_ token: String) {
+        do {
+            try keychain.save(key: accessTokenKey, value: token)
+            _accessToken = token
+        } catch {
+            print("Keychain update error: \(error)")
+        }
+    }
+    
+    func clearTokens() {
+        do {
+            try keychain.delete(key: accessTokenKey)
+            try keychain.delete(key: refreshTokenKey)
+            _accessToken = nil
+            _refreshToken = nil
+        } catch {
+            print("Keychain delete error: \(error)")
+        }
+    }
+    
+    var isLoggedIn: Bool {
+        return accessToken != nil
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
Clean Architecture 기반 Network Layer 구현 (Protocol, Error Handling, Token Interceptor)

## 🎫 Changes
- KeychainManager 구현 (토큰 안전 저장)
- TokenManager 구현 (액세스/리프레시 토큰 관리 및 메모리 캐싱)
- APIEndpoint enum 정의 (Google OAuth 포함 인증 API)
- APIError enum 정의 (백엔드 에러 스펙 매핑)
- ErrorResponse DTO 구현 (String/ValidationError 동적 파싱)
- NetworkClient Protocol 정의
- DefaultNetworkClient 구현 (URLSession 기반)
- Token Interceptor 구현 (401 시 자동 갱신 및 재시도)
- 중복 토큰 갱신 방지 로직 (Task 기반)
- HTTPMethod enum 정의

## 🎫 Thoughts
**1. Protocol 기반 설계 선택**
- 초기에는 단순 Service Layer로 갈지 고민
- 테스트 가능성과 확장성을 위해 Protocol + DI 방식 채택
- ViewModel이 구현체가 아닌 Protocol에 의존하도록 설계
- Mock 객체로 쉽게 교체 가능하여 단위 테스트 용이

**2. Keychain 저장소 분리**
- TokenManager와 KeychainManager를 분리할지 통합할지 고민
- 단일 책임 원칙에 따라 분리 결정:
  - KeychainManager: 범용 Keychain 접근 유틸리티
  - TokenManager: 토큰 전용 비즈니스 로직
- 재사용성 확보 (다른 민감 데이터도 Keychain 저장 가능)
- 테스트 시 KeychainManager만 Mock으로 교체 가능

**3. Alamofire vs URLSession**
- Token Interceptor 구현 시 Alamofire 사용 고민
- 포트폴리오 관점에서 네이티브 URLSession으로 직접 구현 선택
- Async/Await 기반으로 깔끔한 비동기 처리
- 외부 의존성 최소화 및 번들 크기 절감

**4. Error Handling 설계**
- 백엔드 에러 스펙 분석 (400, 401, 403, 404, 422)
- ErrorResponse의 detail 필드가 String 또는 ValidationError 배열로 올 수 있음
- enum DetailType으로 동적 파싱 구현
- ValidationError를 별도 구조체로 분리하여 필드별 에러 처리 가능

**5. Token Interceptor 구현**
- 401 응답 시 자동으로 토큰 갱신 후 원래 요청 재시도
- Task를 활용한 중복 갱신 방지 (동시에 여러 API 호출 시)
- 갱신 실패 시 토큰 클리어 및 로그아웃 처리
- 무한 재시도 방지 (isRetry 플래그)

**6. 메모리 캐싱 전략**
- TokenManager에서 메모리 캐시 구현
- 매번 Keychain 접근하는 성능 이슈 해결
- 앱 실행 중에는 메모리 캐시 우선, 없으면 Keychain 조회

## 🎫 Screenshot
N/A (Infrastructure Layer - UI 없음)

## 🎫 To Reviewers
- Token Interceptor의 중복 갱신 방지 로직이 Thread-Safe한지 검토 해봐야함
- ErrorResponse의 동적 파싱 로직이 모든 케이스를 커버하는지 확인 해야함 

## 🖥️ 주요 코드 설명

`KeychainManager`
- Security Framework 활용한 안전한 토큰 저장
- CRUD 기본 기능 제공
```swift
class KeychainManager {
    static let shared = KeychainManager()
    
    func save(key: String, value: String) throws {
        guard let data = value.data(using: .utf8) else {
            throw KeychainError.unknown(errSecParam)
        }
        
        let query: [String: Any] = [
            kSecClass as String: kSecClassGenericPassword,
            kSecAttrAccount as String: key,
            kSecValueData as String: data,
            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
        ]
        
        let status = SecItemAdd(query as CFDictionary, nil)
        
        if status == errSecDuplicateItem {
            try update(key: key, value: value)
        } else if status != errSecSuccess {
            throw KeychainError.unknown(status)
        }
    }
    
    func get(key: String) throws -> String? {
        // Keychain 조회 로직
    }
}
```

`TokenManager`
- 토큰 관리 및 메모리 캐싱
- KeychainManager를 활용한 영구 저장
```swift
class TokenManager {
    static let shared = TokenManager()
    private let keychain = KeychainManager.shared
    
    // 메모리 캐시
    private var _accessToken: String?
    private var _refreshToken: String?
    
    var accessToken: String? {
        if let token = _accessToken {
            return token
        }
        _accessToken = try? keychain.get(key: accessTokenKey)
        return _accessToken
    }
    
    func saveTokens(access: String, refresh: String) {
        try? keychain.save(key: accessTokenKey, value: access)
        try? keychain.save(key: refreshTokenKey, value: refresh)
        _accessToken = access
        _refreshToken = refresh
    }
}
```

`APIEndpoint`
- 엔드포인트 정의 및 HTTP Method 매핑
```swift
enum APIEndpoint {
    case googleLogin
    case googleCallback
    case refreshToken
    case logout
    
    var path: String {
        switch self {
        case .googleLogin:
            return "/api/v1/auth/google"
        case .googleCallback:
            return "/api/v1/auth/google/callback"
        // ...
        }
    }
    
    var method: HTTPMethod {
        switch self {
        case .googleLogin, .googleCallback:
            return .get
        case .refreshToken, .logout:
            return .post
        }
    }
}
```

`APIError`
- 백엔드 에러 스펙에 맞춘 에러 타입 정의
- 상태 코드별 명확한 에러 메시지
```swift
enum APIError: Error {
    case badRequest(message: String)           // 400
    case unauthorized(message: String)         // 401
    case forbidden(message: String)            // 403
    case notFound(message: String)             // 404
    case validationError(errors: [ValidationError])  // 422
    case serverError(message: String)          // 500
    // ...
}

struct ErrorResponse: Decodable {
    let detail: DetailType
    
    enum DetailType: Decodable {
        case string(String)
        case validationErrors([ValidationErrorDetail])
        
        init(from decoder: Decoder) throws {
            let container = try decoder.singleValueContainer()
            
            if let stringValue = try? container.decode(String.self) {
                self = .string(stringValue)
                return
            }
            
            if let arrayValue = try? container.decode([ValidationErrorDetail].self) {
                self = .validationErrors(arrayValue)
                return
            }
            
            throw DecodingError.typeMismatch(DetailType.self, ...)
        }
    }
}
```

`NetworkClient Protocol`
- 네트워크 요청 추상화
- 테스트 가능하도록 Protocol로 정의
```swift
protocol NetworkClient {
    func request<T: Decodable>(
        endpoint: APIEndpoint,
        body: Encodable?
    ) async throws -> T
    
    func request(
        endpoint: APIEndpoint,
        body: Encodable?
    ) async throws
}
```

`DefaultNetworkClient`
- URLSession 기반 네트워크 클라이언트 구현
- Token Interceptor 로직 포함
```swift
class DefaultNetworkClient: NetworkClient {
    private var refreshTask: Task<Void, Error>?
    
    private func performRequest(
        endpoint: APIEndpoint,
        body: Encodable?,
        isRetry: Bool = false
    ) async throws -> Data {
        // 1. URLRequest 생성
        var request = try createURLRequest(endpoint: endpoint, body: body)
        
        // 2. 토큰 추가
        if let accessToken = tokenManager.accessToken {
            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
        }
        
        // 3. 요청 실행
        let (data, response) = try await URLSession.shared.data(for: request)
        
        // 4. 상태 코드 처리
        switch httpResponse.statusCode {
        case 200...299:
            return data
        case 401:
            if !isRetry {
                try await refreshAccessToken()
                return try await performRequest(endpoint: endpoint, body: body, isRetry: true)
            }
            throw APIError.unauthorized(message: "인증 실패")
        // ...
        }
    }
    
    private func refreshAccessToken() async throws {
        // 중복 갱신 방지
        if let task = refreshTask {
            return try await task.value
        }
        
        let task = Task {
            // 토큰 갱신 로직
        }
        
        refreshTask = task
        try await task.value
        refreshTask = nil
    }
}
```

`에러 파싱`
- 백엔드 응답에 따라 동적으로 에러 파싱
```swift
private func parseErrorResponse(from data: Data) throws -> String {
    let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
    
    switch errorResponse.detail {
    case .string(let message):
        return message
    case .validationErrors:
        return "검증 오류가 발생했습니다."
    }
}

private func parseValidationErrors(from data: Data) throws -> [ValidationError] {
    let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
    
    switch errorResponse.detail {
    case .validationErrors(let details):
        return details.map { ValidationError(from: $0) }
    case .string:
        return []
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #17 