### PR TITLE
[Feat] Experience API 도메인별 Endpoint 분리 및 Repository Layer 구현

### DIFF
--- a/Logit/Logit/Network/Core/DefaultNetworkClient.swift
+++ b/Logit/Logit/Network/Core/DefaultNetworkClient.swift
@@ -22,7 +22,7 @@ class DefaultNetworkClient: NetworkClient {
     
     
     func request<T: Decodable>(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable? = nil
     ) async throws -> T {
         let data = try await performRequest(endpoint: endpoint, body: body)
@@ -36,7 +36,7 @@ class DefaultNetworkClient: NetworkClient {
     }
     
     func request(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable? = nil
     ) async throws {
         _ = try await performRequest(endpoint: endpoint, body: body)
@@ -44,7 +44,7 @@ class DefaultNetworkClient: NetworkClient {
     
     
     private func performRequest(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable?,
         isRetry: Bool = false
     ) async throws -> Data {
@@ -106,7 +106,7 @@ class DefaultNetworkClient: NetworkClient {
     }
     
     private func createURLRequest(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable?
     ) throws -> URLRequest {
         // URL 생성
@@ -167,7 +167,7 @@ class DefaultNetworkClient: NetworkClient {
             
             // Refresh Token으로 새 Access Token 받기
             let request = try createURLRequest(
-                endpoint: .refreshToken,
+                endpoint: AuthEndpoint.refreshToken,
                 body: RefreshTokenRequest(refreshToken: refreshToken)
             )
             

--- a/Logit/Logit/Network/Core/DefaultNetworkClient.swift
+++ b/Logit/Logit/Network/Core/DefaultNetworkClient.swift
@@ -22,7 +22,7 @@ class DefaultNetworkClient: NetworkClient {
     
     
     func request<T: Decodable>(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable? = nil
     ) async throws -> T {
         let data = try await performRequest(endpoint: endpoint, body: body)
@@ -36,7 +36,7 @@ class DefaultNetworkClient: NetworkClient {
     }
     
     func request(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable? = nil
     ) async throws {
         _ = try await performRequest(endpoint: endpoint, body: body)
@@ -44,7 +44,7 @@ class DefaultNetworkClient: NetworkClient {
     
     
     private func performRequest(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable?,
         isRetry: Bool = false
     ) async throws -> Data {
@@ -106,7 +106,7 @@ class DefaultNetworkClient: NetworkClient {
     }
     
     private func createURLRequest(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable?
     ) throws -> URLRequest {
         // URL 생성

--- a/Logit/Logit/Network/Core/EndPoint/AuthEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/AuthEndpoint.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum APIEndpoint {
+enum AuthEndpoint {
     // Auth
     case googleLogin // 구글 로그인
     case googleCallback // 구글 콜백
@@ -35,12 +35,4 @@ enum APIEndpoint {
             return .post
         }
     }
-}
-
-enum HTTPMethod: String {
-    case get = "GET"
-    case post = "POST"
-    case put = "PUT"
-    case delete = "DELETE"
-    case patch = "PATCH"
 }

--- a/Logit/Logit/Network/Core/EndPoint/AuthEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/AuthEndpoint.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum AuthEndpoint {
+enum AuthEndpoint:Endpoint {
     // Auth
     case googleLogin // 구글 로그인
     case googleCallback // 구글 콜백

--- a/Logit/Logit/Network/Core/EndPoint/EndPoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/EndPoint.swift
@@ -1,0 +1,13 @@
+//
+//  EndPoint.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+protocol Endpoint {
+    var path: String { get }
+    var method: HTTPMethod { get }
+}

--- a/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
@@ -10,7 +10,7 @@ import Foundation
 enum ExperienceEndpoint: Endpoint {
     case createExperience           // 경험 등록
     case getExperienceList(limit:Int, offset:Int)          // 경험 목록 조회
-    case searchExperiences          // 경험 검색
+    case searchExperiences(query: String, limit: Int)         // 경험 검색
     case getExperienceDetail(experienceId: String)  // 경험 상세 조회
     case updateExperience(experienceId:String)     // 경험 수정
     case deleteExperience(experienceId:String)     // 경험 삭제
@@ -23,8 +23,10 @@ enum ExperienceEndpoint: Endpoint {
         case .getExperienceList(let limit, let offset):
             let limitValue = min(limit, 1000)
            return "/api/v1/experiences?limit=\(limitValue)&offset=\(offset)"
-        case .searchExperiences:
-            return "/api/v1/experiences/search"
+        case .searchExperiences(let query, let limit):
+               let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+               let limitValue = min(limit, 100)  
+               return "/api/v1/experiences/search?q=\(encodedQuery)&limit=\(limitValue)"
         case .getExperienceDetail(let id):
             return "/api/v1/experiences/\(id)"
         case .updateExperience(let id):

--- a/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
@@ -1,0 +1,48 @@
+//
+//  ExperienceEndpoint.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+enum ExperienceEndpoint: Endpoint {
+    case createExperience           // 경험 등록
+    case getExperienceList          // 경험 목록 조회
+    case searchExperiences          // 경험 검색
+    case getExperienceDetail(experienceId: String)  // 경험 상세 조회
+    case updateExperience(experienceId: String)     // 경험 수정
+    case deleteExperience(experienceId: String)     // 경험 삭제
+    case getMatchingExperiences(questionId: String)     // 문항과 매칭되는 경험 조회
+    
+    var path: String {
+        switch self {
+        case .createExperience, .getExperienceList:
+            return "/api/v1/experiences"
+        case .searchExperiences:
+            return "/api/v1/experiences/search"
+        case .getExperienceDetail(let id):
+            return "/api/v1/experiences/\(id)"
+        case .updateExperience(let id):
+            return "/api/v1/experiences/\(id)"
+        case .deleteExperience(let id):
+            return "/api/v1/experiences/\(id)"
+        case .getMatchingExperiences(let id):
+            return "/api/v1/experiences/match-question/\(id)"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .createExperience:
+            return .post
+        case .getExperienceList, .searchExperiences, .getExperienceDetail, .getMatchingExperiences:
+            return .get
+        case .updateExperience:
+            return .patch
+        case .deleteExperience:
+            return .delete
+        }
+    }
+}

--- a/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ExperienceEndpoint.swift
@@ -9,17 +9,20 @@ import Foundation
 
 enum ExperienceEndpoint: Endpoint {
     case createExperience           // 경험 등록
-    case getExperienceList          // 경험 목록 조회
+    case getExperienceList(limit:Int, offset:Int)          // 경험 목록 조회
     case searchExperiences          // 경험 검색
     case getExperienceDetail(experienceId: String)  // 경험 상세 조회
-    case updateExperience(experienceId: String)     // 경험 수정
-    case deleteExperience(experienceId: String)     // 경험 삭제
-    case getMatchingExperiences(questionId: String)     // 문항과 매칭되는 경험 조회
+    case updateExperience(experienceId:String)     // 경험 수정
+    case deleteExperience(experienceId:String)     // 경험 삭제
+    case getMatchingExperiences(questionId:String)     // 문항과 매칭되는 경험 조회
     
     var path: String {
         switch self {
-        case .createExperience, .getExperienceList:
+        case .createExperience:
             return "/api/v1/experiences"
+        case .getExperienceList(let limit, let offset):
+            let limitValue = min(limit, 1000)
+           return "/api/v1/experiences?limit=\(limitValue)&offset=\(offset)"
         case .searchExperiences:
             return "/api/v1/experiences/search"
         case .getExperienceDetail(let id):

--- a/Logit/Logit/Network/Core/EndPoint/HTTPMethod.swift
+++ b/Logit/Logit/Network/Core/EndPoint/HTTPMethod.swift
@@ -1,0 +1,16 @@
+//
+//  HTTPMethod.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/Logit/Logit/Network/Core/NetworkClient.swift
+++ b/Logit/Logit/Network/Core/NetworkClient.swift
@@ -9,13 +9,13 @@ import Foundation
 
 protocol NetworkClient {
     func request<T:Decodable>(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable?
     ) async throws -> T
     
     // 응답 body 없을때
     func request(
-        endpoint: APIEndpoint,
+        endpoint: AuthEndpoint,
         body: Encodable?
     ) async throws
 }

--- a/Logit/Logit/Network/Core/NetworkClient.swift
+++ b/Logit/Logit/Network/Core/NetworkClient.swift
@@ -9,13 +9,13 @@ import Foundation
 
 protocol NetworkClient {
     func request<T:Decodable>(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable?
     ) async throws -> T
     
     // 응답 body 없을때
     func request(
-        endpoint: AuthEndpoint,
+        endpoint: Endpoint,
         body: Encodable?
     ) async throws
 }

--- a/Logit/Logit/Network/Models/Request/CreateExperienceRequest.swift
+++ b/Logit/Logit/Network/Models/Request/CreateExperienceRequest.swift
@@ -1,0 +1,32 @@
+//
+//  CreateExperienceRequest.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+struct CreateExperienceRequest: Encodable {
+    let action: String
+    let category: String
+    let endDate: String
+    let experienceType: String
+    let result: String
+    let situation: String
+    let startDate: String
+    let task: String
+    let title: String
+    
+    enum CodingKeys: String, CodingKey {
+        case action
+        case category
+        case endDate = "end_date"
+        case experienceType = "experience_type"
+        case result
+        case situation
+        case startDate = "start_date"
+        case task
+        case title
+    }
+}

--- a/Logit/Logit/Network/Models/Request/UpdateExperienceRequest.swift
+++ b/Logit/Logit/Network/Models/Request/UpdateExperienceRequest.swift
@@ -1,0 +1,32 @@
+//
+//  UpdateExperienceRequest.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+struct UpdateExperienceRequest: Encodable {
+    let action: String?
+    let category: String?
+    let endDate: String?
+    let experienceType: String?
+    let result: String?
+    let situation: String?
+    let startDate: String?
+    let task: String?
+    let title: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case action
+        case category
+        case endDate = "end_date"
+        case experienceType = "experience_type"
+        case result
+        case situation
+        case startDate = "start_date"
+        case task
+        case title
+    }
+}

--- a/Logit/Logit/Network/Models/Response/ExperienceListResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ExperienceListResponse.swift
@@ -1,0 +1,16 @@
+//
+//  ExperienceListResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+// 경험목록 조회
+struct ExperienceListResponse: Decodable {
+    let experiences: [ExperienceResponse]
+    let limit: Int
+    let offset: Int
+    let total: Int
+}

--- a/Logit/Logit/Network/Models/Response/ExperienceResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ExperienceResponse.swift
@@ -1,0 +1,42 @@
+//
+//  ExperienceResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+struct ExperienceResponse: Decodable {
+    let action: String
+    let category: String
+    let createdAt: String
+    let endDate: String
+    let experienceType: String
+    let id: String
+    let result: String
+    let situation: String
+    let startDate: String
+    let tags: String
+    let task: String
+    let title: String
+    let updatedAt: String
+    let userId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case action
+        case category
+        case createdAt = "created_at"
+        case endDate = "end_date"
+        case experienceType = "experience_type"
+        case id
+        case result
+        case situation
+        case startDate = "start_date"
+        case tags
+        case task
+        case title
+        case updatedAt = "updated_at"
+        case userId = "user_id"
+    }
+}

--- a/Logit/Logit/Network/Models/Response/ExperienceSearchResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ExperienceSearchResponse.swift
@@ -1,0 +1,19 @@
+//
+//  ExperienceSearchResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+struct ExperienceSearchResponse: Decodable {
+    let query: String
+    let results: [ExperienceSearchResult]
+    let total: Int
+}
+
+struct ExperienceSearchResult: Decodable {
+    let experience: ExperienceResponse
+    let score: Double
+}

--- a/Logit/Logit/Network/Models/Response/MatchingExperiencesResponse.swift
+++ b/Logit/Logit/Network/Models/Response/MatchingExperiencesResponse.swift
@@ -1,0 +1,23 @@
+//
+//  MatchingExperiencesResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+struct MatchingExperiencesResponse: Decodable {
+    let experiences: [MatchingExperience]
+    let total: Int
+}
+
+struct MatchingExperience: Decodable {
+    let experience: ExperienceResponse
+    let similarityScore: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case experience
+        case similarityScore = "similarity_score"
+    }
+}

--- a/Logit/Logit/Network/Repository/ExperienceRepository.swift
+++ b/Logit/Logit/Network/Repository/ExperienceRepository.swift
@@ -9,10 +9,19 @@ import Foundation
 
 protocol ExperienceRepository {
     /// 경험 등록
-   func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse
+    func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse
     /// 경험 목록 조회
     func getExperienceList(limit: Int, offset: Int) async throws -> ExperienceListResponse
-        
+    /// 경험 검색
+    func searchExperiences(query: String, limit: Int) async throws -> ExperienceSearchResponse
+    /// 경험 상세검색
+    func getExperienceDetail(experienceId: String) async throws -> ExperienceResponse
+    /// 경험  수정
+    func updateExperience(experienceId: String, request: UpdateExperienceRequest) async throws -> ExperienceResponse
+    /// 경험  삭제
+    func deleteExperience(experienceId: String) async throws
+    /// 문항 매칭 경험 조회
+    func getMatchingExperiences(questionId: String) async throws -> MatchingExperiencesResponse
 }
 
 
@@ -39,4 +48,44 @@ class DefaultExperienceRepository: ExperienceRepository {
                 body: nil as Empty?
             )
         }
+    
+    // 경험 검색
+    func searchExperiences(query: String, limit: Int = 10) async throws -> ExperienceSearchResponse {
+        return try await networkClient.request(
+            endpoint: ExperienceEndpoint.searchExperiences(query: query, limit: limit),
+            body: nil as Empty?
+        )
+    }
+    
+    // 경험 상세 조회
+    func getExperienceDetail(experienceId: String) async throws -> ExperienceResponse {
+        return try await networkClient.request(
+            endpoint: ExperienceEndpoint.getExperienceDetail(experienceId: experienceId),
+            body: nil as Empty?
+        )
+    }
+    
+    // 경험 상세 조회
+    func updateExperience(experienceId: String, request: UpdateExperienceRequest) async throws -> ExperienceResponse {
+        return try await networkClient.request(
+            endpoint: ExperienceEndpoint.updateExperience(experienceId: experienceId),
+            body: request
+        )
+    }
+    
+    // 경험 삭제
+    func deleteExperience(experienceId: String) async throws {
+        try await networkClient.request(
+            endpoint: ExperienceEndpoint.deleteExperience(experienceId: experienceId),
+            body: nil as Empty?
+        )
+    }
+    
+    // 문항 매칭 경험 조회
+    func getMatchingExperiences(questionId: String) async throws -> MatchingExperiencesResponse {
+        return try await networkClient.request(
+            endpoint: ExperienceEndpoint.getMatchingExperiences(questionId: questionId),
+            body: nil as Empty?
+        )
+    }
 }

--- a/Logit/Logit/Network/Repository/ExperienceRepository.swift
+++ b/Logit/Logit/Network/Repository/ExperienceRepository.swift
@@ -1,0 +1,42 @@
+//
+//  ExperienceRepository.swift
+//  Logit
+//
+//  Created by 임재현 on 1/30/26.
+//
+
+import Foundation
+
+protocol ExperienceRepository {
+    /// 경험 등록
+   func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse
+    /// 경험 목록 조회
+    func getExperienceList(limit: Int, offset: Int) async throws -> ExperienceListResponse
+        
+}
+
+
+class DefaultExperienceRepository: ExperienceRepository {
+    
+    private let networkClient: NetworkClient
+    
+    init(networkClient: NetworkClient) {
+        self.networkClient = networkClient
+    }
+  
+    // 경험 등록
+    func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse {
+        return try await networkClient.request(
+            endpoint: ExperienceEndpoint.createExperience,
+            body: request
+        )
+    }
+    // 경험 목록 조회
+    func getExperienceList(limit: Int = 100, offset: Int = 0) async throws -> ExperienceListResponse {
+            // Query parameter는 endpoint에서 처리하거나 여기서 URL에 추가
+            return try await networkClient.request(
+                endpoint: ExperienceEndpoint.getExperienceList(limit: limit, offset: offset),
+                body: nil as Empty?
+            )
+        }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
Experience API 도메인별 Endpoint 분리 및 Repository Layer 구현

## 🎫 Changes
- Endpoint Protocol 정의 및 도메인별 Endpoint 분리
- ExperienceEndpoint 구현 (7개 API)
- Experience 관련 DTO 정의 (Request/Response Models)
- ExperienceRepository Protocol 정의
- DefaultExperienceRepository 구현
- Query Parameter 처리 로직 구현
- MockExperienceRepository 구현 (테스트용)

## 🎫 Thoughts
**1. Endpoint 관리 방식 선택**
- 초기 고민: 하나의 APIEndpoint vs 도메인별 분리 vs Protocol 기반
- 최종 선택: **Protocol 기반 도메인별 분리**
  - AuthEndpoint, ExperienceEndpoint 등으로 분리
  - 각 도메인이 Endpoint Protocol 채택
  - 관심사 분리 및 확장성 확보
- 장점:
  - 파일 크기 적절하게 유지
  - Merge Conflict 최소화
  - 도메인별 독립적 관리
  - 새 도메인 추가 시 기존 코드 영향 없음

**2. Query Parameter 처리 방식**
- 고민한 방식들:
  - 방식 1: Endpoint path에서 직접 문자열로 처리
  - 방식 2: Repository에서 URL 직접 조작
  - 방식 3: Endpoint에 queryItems 프로퍼티 추가 (URLComponents 활용)
- 최종 선택: **방식 1 (Endpoint path에서 직접 처리)**
  - Protocol 수정 불필요
  - NetworkClient 수정 불필요
  - 간단하고 직관적
  - 쿼리 필요한 것들만 path에 추가
- 장점:
  - 구현이 단순하고 명확
  - 기존 구조 변경 없이 적용 가능
  - 타입 안전성 유지 (enum case에 파라미터 명시)

**3. DTO 설계**
- Response DTO 재사용 전략:
  - `ExperienceResponse`를 경험 등록/상세/수정에서 공통 사용
  - 리스트, 검색, 매칭은 별도 래퍼 타입 정의
- CodingKeys로 snake_case ↔ camelCase 매핑
- 날짜는 String으로 받아 유연성 확보 (필요시 Date 변환)

**4. Repository Pattern 적용**
- Protocol로 추상화하여 테스트 가능성 확보
- DefaultExperienceRepository: 실제 API 호출
- MockExperienceRepository: 테스트용 구현체
- ViewModel은 Protocol에만 의존 (DI)

**5. API 스펙 반영**
- limit 최대값 검증 (경험 목록: 1000, 검색: 100)
- 기본값 처리 (경험 목록: limit 100/offset 0, 검색: limit 10)
- URL 인코딩 처리 (검색어 특수문자 대응)
- PATCH vs PUT 메서드 선택 (부분 업데이트는 PATCH)

## 🎫 Screenshot
N/A (Data Layer - UI 없음)

## 🎫 To Reviewers
- Query Parameter를 path에서 직접 처리하는 방식이 확장성 측면에서 문제없을까 고민
- DTO ↔ Domain Entity 매핑 레이어가 필요한지 잘 모르겠다

## 🖥️ 주요 코드 설명

`Endpoint Protocol`
- 모든 Endpoint가 채택해야 하는 기본 인터페이스
- path와 method만 요구하여 단순성 유지
```swift
protocol Endpoint {
    var path: String { get }
    var method: HTTPMethod { get }
}

enum HTTPMethod: String {
    case get = "GET"
    case post = "POST"
    case put = "PUT"
    case delete = "DELETE"
    case patch = "PATCH"
}
```

`ExperienceEndpoint`
- 경험 관련 7개 API endpoint 정의
- Query parameter는 path에서 직접 처리
```swift
enum ExperienceEndpoint: Endpoint {
    case createExperience
    case getExperienceList(limit: Int, offset: Int)
    case searchExperiences(query: String, limit: Int)
    case getExperienceDetail(experienceId: String)
    case updateExperience(experienceId: String)
    case deleteExperience(experienceId: String)
    case getMatchingExperiences(questionId: String)
    
    var path: String {
        switch self {
        case .getExperienceList(let limit, let offset):
            let limitValue = min(limit, 1000)
            return "/api/v1/experiences?limit=\(limitValue)&offset=\(offset)"
            
        case .searchExperiences(let query, let limit):
            let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
            let limitValue = min(limit, 100)
            return "/api/v1/experiences/search?q=\(encodedQuery)&limit=\(limitValue)"
        
        // ...
        }
    }
}
```

`Experience DTO Models`
- Request/Response 모델 정의
- CodingKeys로 네이밍 매핑
```swift
// 경험 등록 요청
struct CreateExperienceRequest: Encodable {
    let action: String
    let category: String
    let endDate: String
    let experienceType: String
    // ...
    
    enum CodingKeys: String, CodingKey {
        case action
        case category
        case endDate = "end_date"
        case experienceType = "experience_type"
        // ...
    }
}

// 경험 응답 (등록/상세/수정 공통)
struct ExperienceResponse: Decodable {
    let id: String
    let title: String
    let category: String
    let tags: String
    let createdAt: String
    // ...
}

// 경험 목록 응답
struct ExperienceListResponse: Decodable {
    let experiences: [ExperienceResponse]
    let limit: Int
    let offset: Int
    let total: Int
}

// 경험 검색 응답
struct ExperienceSearchResponse: Decodable {
    let query: String
    let results: [ExperienceSearchResult]
    let total: Int
}

struct ExperienceSearchResult: Decodable {
    let experience: ExperienceResponse
    let score: Double
}

// 경험 수정 요청 (부분 업데이트)
struct UpdateExperienceRequest: Encodable {
    let action: String?
    let category: String?
    let title: String?
    // 모든 필드 Optional
}
```

`ExperienceRepository Protocol`
- 경험 관련 비즈니스 로직 추상화
- 7개 API 메서드 정의
```swift
protocol ExperienceRepository {
    func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse
    func getExperienceList(limit: Int, offset: Int) async throws -> ExperienceListResponse
    func searchExperiences(query: String, limit: Int) async throws -> ExperienceSearchResponse
    func getExperienceDetail(experienceId: String) async throws -> ExperienceResponse
    func updateExperience(experienceId: String, request: UpdateExperienceRequest) async throws -> ExperienceResponse
    func deleteExperience(experienceId: String) async throws
    func getMatchingExperiences(questionId: String) async throws -> MatchingExperiencesResponse
}
```

`DefaultExperienceRepository`
- NetworkClient를 활용한 실제 API 호출 구현
- 기본값 처리 및 NetworkClient에 위임
```swift
class DefaultExperienceRepository: ExperienceRepository {
    private let networkClient: NetworkClient
    
    init(networkClient: NetworkClient) {
        self.networkClient = networkClient
    }
    
    func getExperienceList(limit: Int = 100, offset: Int = 0) async throws -> ExperienceListResponse {
        return try await networkClient.request(
            endpoint: ExperienceEndpoint.getExperienceList(limit: limit, offset: offset),
            body: nil as Empty?
        )
    }
    
    func searchExperiences(query: String, limit: Int = 10) async throws -> ExperienceSearchResponse {
        return try await networkClient.request(
            endpoint: ExperienceEndpoint.searchExperiences(query: query, limit: limit),
            body: nil as Empty?
        )
    }
    
    func createExperience(_ request: CreateExperienceRequest) async throws -> ExperienceResponse {
        return try await networkClient.request(
            endpoint: ExperienceEndpoint.createExperience,
            body: request
        )
    }
    
    // ...
}
```

`ViewModel 연동 예시`
- Repository를 DI로 주입받아 사용
- Protocol 의존으로 테스트 가능
```swift
class ExperienceFlowViewModel: ObservableObject {
    private let repository: ExperienceRepository
    
    init(repository: ExperienceRepository = DefaultExperienceRepository(
        networkClient: DefaultNetworkClient()
    )) {
        self.repository = repository
    }
    
    func saveExperience() async {
        do {
            let request = CreateExperienceRequest(
                action: action,
                category: selectedCompetency ?? "",
                endDate: endDate,
                experienceType: experienceType ?? "",
                result: result,
                situation: situation,
                startDate: startDate,
                task: task,
                title: experienceTitle
            )
            
            let response = try await repository.createExperience(request)
            print("경험 등록 성공: \(response.id)")
            
        } catch let error as APIError {
            print("에러: \(error.localizedDescription)")
        }
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #25 