### PR TITLE
[feat] SSE(Server-Sent Events) 스트리밍 기반 실시간 채팅 기능 구현을 위한 Network Layer 작업

### DIFF
--- a/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
@@ -1,0 +1,26 @@
+//
+//  ChatEndpoint.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+enum ChatEndpoint: Endpoint {
+    case sendMessage  // 메시지 전송 (SSE 스트리밍)
+    
+    var path: String {
+        switch self {
+        case .sendMessage:
+            return "/api/v1/projects/chats"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .sendMessage:
+            return .post
+        }
+    }
+}

--- a/Logit/Logit/Network/Core/EndPoint/SSEClient.swift
+++ b/Logit/Logit/Network/Core/EndPoint/SSEClient.swift
@@ -1,0 +1,208 @@
+//
+//  SSEClient.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+protocol SSEClient {
+    func stream(
+        endpoint: Endpoint,
+        body: Encodable?
+    ) -> AsyncThrowingStream<ChatSSEEvent, Error>
+}
+
+
+class DefaultSSEClient: SSEClient {
+    private let baseURL: String
+    private let tokenManager: TokenManager
+    private let timeoutInterval: TimeInterval
+    
+    init(
+        baseURL: String = "https://api.example.com",
+        tokenManager: TokenManager = .shared,
+        timeoutInterval: TimeInterval = 120  // 기본 2분
+    ) {
+        self.baseURL = baseURL
+        self.tokenManager = tokenManager
+        self.timeoutInterval = timeoutInterval
+    }
+    
+    func stream(
+        endpoint: Endpoint,
+        body: Encodable?
+    ) -> AsyncThrowingStream<ChatSSEEvent, Error> {
+        return AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    // 1. URLRequest 생성
+                    var request = try createURLRequest(endpoint: endpoint, body: body)
+                    
+                    // 2. 타임아웃 설정
+                    request.timeoutInterval = timeoutInterval
+                    
+                    // 3. 토큰 추가
+                    if let accessToken = tokenManager.accessToken {
+                        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+                    }
+                    
+                    // 4. URLSession.bytes로 스트리밍
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    
+                    // 5. HTTP 응답 검증
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw APIError.invalidResponse
+                    }
+                    
+                    // 6. 상태코드별 처리 (연결 전 에러)
+                    switch httpResponse.statusCode {
+                    case 200...299:
+                        break  // 정상 → 스트리밍 진행
+                        
+                    case 400:
+                        throw APIError.badRequest(message: "잘못된 요청입니다.")
+                        
+                    case 401:
+                        throw APIError.unauthorized(message: "인증이 필요합니다.")
+                        
+                    case 403:
+                        throw APIError.forbidden(message: "접근 권한이 없습니다.")
+                        
+                    case 404:
+                        throw APIError.notFound(message: "리소스를 찾을 수 없습니다.")
+                        
+                    case 422:
+                        throw APIError.validationError(errors: [
+                            ValidationError(
+                                from: ValidationErrorDetail(
+                                    loc: ["unknown"],
+                                    msg: "요청 데이터를 확인해주세요.",
+                                    type: "validation_error"
+                                )
+                            )
+                        ])
+                        
+                    case 429:
+                        throw APIError.unknown(
+                            statusCode: 429,
+                            message: "일일 채팅 제한을 초과했습니다."
+                        )
+                        
+                    case 500...599:
+                        throw APIError.serverError(message: "서버 오류가 발생했습니다.")
+                        
+                    default:
+                        throw APIError.unknown(statusCode: httpResponse.statusCode, message: nil)
+                    }
+                    
+                    // 7. 스트리밍 데이터 파싱
+                    var receivedDone = false
+                    var buffer = ""
+                    
+                    for try await byte in bytes {
+                        let character = Character(UnicodeScalar(byte))
+                        buffer.append(character)
+                        
+                        // SSE 이벤트는 \n\n으로 구분됨
+                        if buffer.hasSuffix("\n\n") {
+                            let eventData = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+                            
+                            if let event = parseSSEEvent(eventData) {
+                                continuation.yield(event)
+                                
+                                // done 이벤트 받으면 정상 종료
+                                if case .done = event {
+                                    receivedDone = true
+                                    continuation.finish()
+                                    return
+                                }
+                                
+                                // error 이벤트 받으면 에러 종료
+                                if case .error(let message) = event {
+                                    continuation.finish(throwing: APIError.serverError(message: message))
+                                    return
+                                }
+                            }
+                            
+                            buffer = ""
+                        }
+                    }
+                    
+                    // 8. done 없이 종료되면 비정상 종료
+                    if !receivedDone {
+                        continuation.finish(throwing: APIError.serverError(
+                            message: "스트리밍이 비정상 종료되었습니다."
+                        ))
+                    }
+                    
+                } catch let error as URLError where error.code == .timedOut {
+                    // 타임아웃 에러 명시적 처리
+                    continuation.finish(throwing: APIError.serverError(
+                        message: "응답 시간이 초과되었습니다. 다시 시도해주세요."
+                    ))
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+    
+    private func createURLRequest(
+        endpoint: Endpoint,
+        body: Encodable?
+    ) throws -> URLRequest {
+        guard let url = URL(string: baseURL + endpoint.path) else {
+            throw APIError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        
+        // Body 추가
+        if let body = body {
+            request.httpBody = try JSONEncoder().encode(body)
+        }
+        
+        return request
+    }
+    
+    private func parseSSEEvent(_ eventData: String) -> ChatSSEEvent? {
+        // "data: " 접두사 제거
+        guard eventData.hasPrefix("data: ") else {
+            return nil
+        }
+        
+        let jsonString = eventData.replacingOccurrences(of: "data: ", with: "")
+        guard let data = jsonString.data(using: .utf8) else {
+            return nil
+        }
+        
+        let decoder = JSONDecoder()
+        
+        // type 필드로 어떤 이벤트인지 판단
+        if let contentEvent = try? decoder.decode(ChatContentEvent.self, from: data),
+           contentEvent.type == "content" {
+            return .content(contentEvent.content)
+        }
+        
+        if let doneEvent = try? decoder.decode(ChatDoneEvent.self, from: data),
+           doneEvent.type == "done" {
+            return .done(
+                chatId: doneEvent.chatId,
+                isDraft: doneEvent.isDraft,
+                remainingChats: doneEvent.remainingChats
+            )
+        }
+        
+        if let errorEvent = try? decoder.decode(ChatErrorEvent.self, from: data),
+           errorEvent.type == "error" {
+            return .error(errorEvent.message)
+        }
+        
+        return nil
+    }
+}

--- a/Logit/Logit/Network/Models/Request/SendMessageRequest.swift
+++ b/Logit/Logit/Network/Models/Request/SendMessageRequest.swift
@@ -1,0 +1,20 @@
+//
+//  SendMessageRequest.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+struct SendMessageRequest: Encodable {
+    let content: String
+    let experienceIds: [String]
+    let questionId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case content
+        case experienceIds = "experience_ids"
+        case questionId = "question_id"
+    }
+}

--- a/Logit/Logit/Network/Models/Response/ChatSSEEvent.swift
+++ b/Logit/Logit/Network/Models/Response/ChatSSEEvent.swift
@@ -1,0 +1,38 @@
+//
+//  ChatSSEEvent.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+enum ChatSSEEvent {
+    case content(String)
+    case done(chatId: String, isDraft: Bool, remainingChats: Int)
+    case error(String)
+}
+
+struct ChatContentEvent: Decodable {
+    let type: String
+    let content: String
+}
+
+struct ChatDoneEvent: Decodable {
+    let type: String
+    let chatId: String
+    let isDraft: Bool
+    let remainingChats: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case chatId = "chat_id"
+        case isDraft = "is_draft"
+        case remainingChats = "remaining_chats"
+    }
+}
+
+struct ChatErrorEvent: Decodable {
+    let type: String
+    let message: String
+}

--- a/Logit/Logit/Network/Repository/ChatRepository.swift
+++ b/Logit/Logit/Network/Repository/ChatRepository.swift
@@ -1,0 +1,36 @@
+//
+//  ChatRepository.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+protocol ChatRepository {
+    /// 메시지 전송 (SSE 스트리밍)
+    func sendMessage(
+        projectId: String,
+        request: SendMessageRequest
+    ) -> AsyncThrowingStream<ChatSSEEvent, Error>
+}
+
+class DefaultChatRepository: ChatRepository {
+    
+    private let sseClient: SSEClient
+    
+    init(sseClient: SSEClient) {
+        self.sseClient = sseClient
+    }
+    
+    // 메시지 전송 (SSE 스트리밍)
+    func sendMessage(
+        projectId: String,
+        request: SendMessageRequest
+    ) -> AsyncThrowingStream<ChatSSEEvent, Error> {
+        return sseClient.stream(
+            endpoint: ChatEndpoint.sendMessage,
+            body: request
+        )
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
SSE(Server-Sent Events) 스트리밍 기반 실시간 채팅 기능 구현을 위한 Network Layer 작업

## 🎫 Changes
- `ChatEndpoint` 구현 (메시지 전송 API 엔드포인트)
- `SendMessageRequest` DTO 구현 (채팅 요청 모델)
- `ChatSSEEvent` enum 구현 (content, done, error 이벤트 타입 정의)
- SSE 응답 파싱을 위한 DTO 구현 (`ChatContentEvent`, `ChatDoneEvent`, `ChatErrorEvent`)
- `SSEClient` Protocol 정의 (스트리밍 전용 클라이언트 인터페이스)
- `DefaultSSEClient` 구현 (SSE 스트리밍 처리 및 다층 에러 방어)
- `ChatRepository` Protocol 정의
- `DefaultChatRepository` 구현

## 🎫 Thoughts

### **SSE vs 일반 HTTP의 근본적 차이**
기존 `NetworkClient`는 `URLSession.data(for:)`를 사용하여 응답 전체를 기다리는 방식이었습니다. 하지만 SSE는 서버가 실시간으로 데이터를 스트리밍하는 방식이므로, `URLSession.bytes(for:)`를 사용하여 바이트 단위로 데이터를 수신해야 합니다. 이로 인해 별도의 `SSEClient`를 분리하여 구현했습니다.

### **에러 처리의 이중 구조**
SSE의 특수성으로 인해 에러가 두 가지 시점에서 발생할 수 있습니다:

1. **연결 전 에러 (422, 429 등)**: HTTP 상태코드로 감지 가능하지만, `URLSession.bytes`의 특성상 response body를 읽을 수 없어 generic 에러 메시지만 제공
2. **스트리밍 중 에러**: 이미 200 OK를 받은 후 발생하는 에러로, SSE 이벤트 `{"type": "error"}`로 전달되며 상세 메시지 파싱 가능

### **Done 플래그 방어의 중요성**
서버가 `{"type": "done"}` 이벤트를 보내지 않고 연결을 종료하는 경우, 클라이언트는 응답이 완료되었는지 불완전한지 판단할 수 없습니다. `receivedDone` 플래그를 통해 done 이벤트를 명시적으로 받은 경우만 정상 종료로 처리하여, 비정상 종료 시 사용자에게 적절한 피드백을 제공할 수 있도록 했습니다.

### **타임아웃 설정 (120초)**
AI 응답 생성에는 시간이 소요될 수 있으므로 일반 API보다 긴 120초로 설정했습니다. 타임아웃은 연결 타임아웃과 데이터 수신 타임아웃 모두에 적용되며, 데이터 수신 시마다 타이머가 리셋되므로 느리지만 지속적으로 데이터가 오는 경우에는 타임아웃이 발생하지 않습니다.

### **AsyncThrowingStream 선택 이유**
Combine의 `Publisher`나 `@Published`가 아닌 `AsyncThrowingStream`을 사용한 이유는:
- Swift Concurrency의 네이티브 지원으로 async/await와 자연스럽게 통합
- `for try await` 루프로 직관적인 스트리밍 처리
- 백프레셔(backpressure) 자동 처리
- Combine보다 가벼운 의존성

### **관심사 분리 (Separation of Concerns)**
일반 HTTP 요청(`NetworkClient`)과 SSE 스트리밍(`SSEClient`)을 분리함으로써:
- 각 클라이언트의 책임이 명확해짐
- 토큰 갱신 로직 같은 공통 관심사는 `TokenManager`에 위임
- 나중에 WebSocket이나 GraphQL Subscription 추가 시에도 확장 용이

## 🎫 Screenshot
N/A (Network Layer 작업으로 UI 변경 없음)

## 🎫 To Reviewers

### **중점 리뷰 포인트**
1. **에러 처리 전략**: 연결 전 에러(422, 429)에서 response body를 읽을 수 없는 제약이 있습니다. Generic 메시지로 처리한 것이 적절한지 검토 부탁드립니다.
2. **Done 플래그 방어**: `receivedDone` 플래그로 비정상 종료를 감지하는 로직이 견고한지 확인 부탁드립니다.
3. **타임아웃 값**: 120초가 적절한지, 프로덕션 환경에서 조정이 필요한지 의견 부탁드립니다.
4. **AsyncThrowingStream 사용**: Combine 대신 Swift Concurrency를 선택한 것에 대한 의견 부탁드립니다.
5. **SSEClient 분리**: 기존 NetworkClient를 확장하지 않고 별도 클라이언트로 분리한 설계가 적절한지 검토 부탁드립니다.

### **테스트 시 확인 사항**
- 정상 스트리밍 플로우 (content → done)
- 스트리밍 중 에러 발생 (content → error)
- 네트워크 끊김 시나리오
- Done 없이 서버 연결 종료
- 타임아웃 발생 (120초 이상 응답 없음)
- 422, 429 등 연결 전 에러

## 🖥️ 주요 코드 설명

### `ChatEndpoint`
- Project 하위 리소스로 Chat을 관리하는 구조
- SSE 스트리밍 요청을 위한 엔드포인트
```swift
enum ChatEndpoint: Endpoint {
    case sendMessage(projectId: String)  // 메시지 전송 (SSE 스트리밍)
    
    var path: String {
        switch self {
        case .sendMessage(let projectId):
            return "/api/v1/projects/\(projectId)/chats"
        }
    }
    
    var method: HTTPMethod {
        switch self {
        case .sendMessage:
            return .post
        }
    }
}
```

### `SendMessageRequest`
- 채팅 요청 시 필요한 데이터 캡슐화
- `experience_ids`: 참조할 경험 데이터 목록
- `question_id`: 답변할 문항 ID
```swift
struct SendMessageRequest: Encodable {
    let content: String
    let experienceIds: [String]
    let questionId: String
    
    enum CodingKeys: String, CodingKey {
        case content
        case experienceIds = "experience_ids"
        case questionId = "question_id"
    }
}
```

### `ChatSSEEvent`
- SSE 스트리밍으로 수신되는 3가지 이벤트 타입 정의
- `content`: 실시간으로 생성되는 텍스트 조각
- `done`: 스트리밍 완료 및 메타데이터 (chatId, isDraft, remainingChats)
- `error`: 스트리밍 중 발생한 에러
```swift
enum ChatSSEEvent {
    case content(String)
    case done(chatId: String, isDraft: Bool, remainingChats: Int)
    case error(String)
}
```

### `DefaultSSEClient` - 핵심 구현

#### 1. 연결 전 에러 처리 (Status Code 기반)
```swift
switch httpResponse.statusCode {
case 200...299:
    break  // 정상 → 스트리밍 진행
    
case 422:
    // URLSession.bytes는 response body를 읽을 수 없음
    // Generic 메시지만 제공
    throw APIError.validationError(errors: [
        ValidationError(
            from: ValidationErrorDetail(
                loc: ["unknown"],
                msg: "요청 데이터를 확인해주세요.",
                type: "validation_error"
            )
        )
    ])
    
case 429:
    throw APIError.unknown(
        statusCode: 429,
        message: "일일 채팅 제한을 초과했습니다."
    )
    
// ... 기타 상태코드 처리
}
```

**제약사항**: `URLSession.bytes(for:)`는 스트리밍용이므로 초기 response body를 읽을 수 없습니다. 422나 429 에러 발생 시 서버의 상세 에러 정보(`loc`, `remaining` 등)를 파싱할 수 없어, generic 메시지만 제공합니다.

#### 2. 스트리밍 데이터 파싱 및 Done 플래그 방어
```swift
var receivedDone = false  // Done 플래그
var buffer = ""

for try await byte in bytes {
    let character = Character(UnicodeScalar(byte))
    buffer.append(character)
    
    // SSE 이벤트는 \n\n으로 구분됨
    if buffer.hasSuffix("\n\n") {
        let eventData = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
        
        if let event = parseSSEEvent(eventData) {
            continuation.yield(event)
            
            // Done 이벤트 수신 시
            if case .done = event {
                receivedDone = true  // 플래그 설정
                continuation.finish()
                return
            }
            
            // Error 이벤트 수신 시
            if case .error(let message) = event {
                continuation.finish(throwing: APIError.serverError(message: message))
                return
            }
        }
        
        buffer = ""
    }
}

// Done 없이 종료되면 비정상 종료로 간주
if !receivedDone {
    continuation.finish(throwing: APIError.serverError(
        message: "스트리밍이 비정상 종료되었습니다."
    ))
}
```

**핵심 로직**: 
- `receivedDone` 플래그로 서버가 명시적으로 `{"type": "done"}` 이벤트를 보냈는지 추적
- Done 이벤트 없이 for 루프가 종료되면 (서버 크래시, 비정상 종료 등) 에러 처리
- 사용자에게 응답이 불완전함을 알릴 수 있음

#### 3. 타임아웃 처리
```swift
var request = URLRequest(url: url)
request.timeoutInterval = 120  // 2분 타임아웃

// ...

} catch let error as URLError where error.code == .timedOut {
    // 타임아웃 에러 명시적 처리
    continuation.finish(throwing: APIError.serverError(
        message: "응답 시간이 초과되었습니다. 다시 시도해주세요."
    ))
}
```

**타임아웃 동작**:
- 연결 타임아웃: 서버가 120초 내에 응답하지 않으면 에러
- 데이터 수신 타임아웃: 마지막 데이터 수신 후 120초 동안 아무것도 안 오면 에러
- 데이터 수신마다 타이머 리셋 → 느리지만 지속적인 스트리밍은 타임아웃 안 남

#### 4. SSE 이벤트 파싱
```swift
private func parseSSEEvent(_ eventData: String) -> ChatSSEEvent? {
    // "data: " 접두사 제거
    guard eventData.hasPrefix("data: ") else {
        return nil
    }
    
    let jsonString = eventData.replacingOccurrences(of: "data: ", with: "")
    guard let data = jsonString.data(using: .utf8) else {
        return nil
    }
    
    let decoder = JSONDecoder()
    
    // type 필드로 이벤트 타입 판단
    if let contentEvent = try? decoder.decode(ChatContentEvent.self, from: data),
       contentEvent.type == "content" {
        return .content(contentEvent.content)
    }
    
    if let doneEvent = try? decoder.decode(ChatDoneEvent.self, from: data),
       doneEvent.type == "done" {
        return .done(
            chatId: doneEvent.chatId,
            isDraft: doneEvent.isDraft,
            remainingChats: doneEvent.remainingChats
        )
    }
    
    if let errorEvent = try? decoder.decode(ChatErrorEvent.self, from: data),
       errorEvent.type == "error" {
        return .error(errorEvent.message)
    }
    
    return nil
}
```

**SSE 형식**: `data: {JSON}\n\n`
- 각 이벤트는 `data:` 접두사와 `\n\n` 구분자를 가짐
- JSON의 `type` 필드로 이벤트 종류 구분
- 파싱 실패 시 `nil` 반환하여 무시 (잘못된 형식의 이벤트)

### `DefaultChatRepository`
- SSEClient를 주입받아 사용하는 Repository 패턴
- 비즈니스 로직과 네트워크 레이어 분리
```swift
class DefaultChatRepository: ChatRepository {
    
    private let sseClient: SSEClient
    
    init(sseClient: SSEClient) {
        self.sseClient = sseClient
    }
    
    func sendMessage(
        projectId: String,
        request: SendMessageRequest
    ) -> AsyncThrowingStream<ChatSSEEvent, Error> {
        return sseClient.stream(
            endpoint: ChatEndpoint.sendMessage(projectId: projectId),
            body: request
        )
    }
}
```

### 사용 예시 (ViewModel)
```swift
class ChatViewModel: ObservableObject {
    @Published var streamedContent: String = ""
    @Published var isStreaming = false
    @Published var errorMessage: String?
    
    private let repository: ChatRepository
    
    func sendMessage(
        projectId: String,
        content: String,
        experienceIds: [String],
        questionId: String
    ) async {
        isStreaming = true
        streamedContent = ""
        
        let request = SendMessageRequest(
            content: content,
            experienceIds: experienceIds,
            questionId: questionId
        )
        
        let stream = repository.sendMessage(projectId: projectId, request: request)
        
        do {
            for try await event in stream {
                switch event {
                case .content(let text):
                    // 실시간으로 텍스트 누적
                    streamedContent += text
                    
                case .done(let chatId, let isDraft, let remainingChats):
                    // 스트리밍 완료
                    isStreaming = false
                    print("완료 - chatId: \(chatId), isDraft: \(isDraft), remaining: \(remainingChats)")
                    
                case .error(let message):
                    // 서버 에러
                    errorMessage = message
                    isStreaming = false
                }
            }
        } catch {
            // 네트워크 에러, 비정상 종료, 타임아웃 등
            if let apiError = error as? APIError {
                errorMessage = apiError.localizedDescription
            }
            isStreaming = false
        }
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #