### PR TITLE
[feat] Chat 도메인 Network Layer 구현 (채팅 히스토리 조회 및 자기소개서 답변 업데이트 API)

### DIFF
--- a/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
@@ -10,6 +10,7 @@ import Foundation
 enum ChatEndpoint: Endpoint {
     case sendMessage  // 메시지 전송 (SSE 스트리밍)
     case getChatHistory(questionId: String, cursor: String?, size: Int)  // 채팅 히스토리 조회
+    case updateAnswer(chatId: String)                   // 자기소개서 답변 업데이트
     
     var path: String {
         switch self {
@@ -36,6 +37,9 @@ enum ChatEndpoint: Endpoint {
             }
             
             return path
+            
+        case .updateAnswer(let chatId):
+            return "/api/v1/projects/chats/\(chatId)/answer"
         }
     }
     
@@ -45,6 +49,8 @@ enum ChatEndpoint: Endpoint {
             return .post
         case .getChatHistory:
             return .get
+        case .updateAnswer:
+            return .patch
         }
     }
 }

--- a/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ChatEndpoint.swift
@@ -9,11 +9,33 @@ import Foundation
 
 enum ChatEndpoint: Endpoint {
     case sendMessage  // 메시지 전송 (SSE 스트리밍)
+    case getChatHistory(questionId: String, cursor: String?, size: Int)  // 채팅 히스토리 조회
     
     var path: String {
         switch self {
         case .sendMessage:
             return "/api/v1/projects/chats"
+            
+        case .getChatHistory(let questionId, let cursor, let size):
+            var path = "/api/v1/projects/chats/\(questionId)"
+            
+            var queryItems: [String] = []
+            
+            // size 설정 (1~100 범위 제한)
+            let validSize = min(max(size, 1), 100)
+            queryItems.append("size=\(validSize)")
+            
+            // cursor가 있으면 추가
+            if let cursor = cursor {
+                let encodedCursor = cursor.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? cursor
+                queryItems.append("cursor=\(encodedCursor)")
+            }
+            
+            if !queryItems.isEmpty {
+                path += "?" + queryItems.joined(separator: "&")
+            }
+            
+            return path
         }
     }
     
@@ -21,6 +43,8 @@ enum ChatEndpoint: Endpoint {
         switch self {
         case .sendMessage:
             return .post
+        case .getChatHistory:
+            return .get
         }
     }
 }

--- a/Logit/Logit/Network/Models/Request/UpdateAnswerRequest.swift
+++ b/Logit/Logit/Network/Models/Request/UpdateAnswerRequest.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateAnswerRequest.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+struct UpdateAnswerRequest: Encodable {
+    let questionId: String
+    let answer: String
+    
+    enum CodingKeys: String, CodingKey {
+        case questionId = "question_id"
+        case answer
+    }
+}

--- a/Logit/Logit/Network/Models/Response/ChatHistoryResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ChatHistoryResponse.swift
@@ -1,0 +1,56 @@
+//
+//  ChatHistoryResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+struct ChatHistoryResponse: Decodable {
+    let projectName: String
+    let projectCreatedAt: String
+    let questionId: String
+    let question: String
+    let answer: String
+    let chats: [ChatMessage]
+    let experienceIds: [String]
+    let nextCursor: String?
+    let hasMore: Bool
+    let remainingChats: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case projectName = "project_name"
+        case projectCreatedAt = "project_created_at"
+        case questionId = "question_id"
+        case question
+        case answer
+        case chats
+        case experienceIds = "experience_ids"
+        case nextCursor = "next_cursor"
+        case hasMore = "has_more"
+        case remainingChats = "remaining_chats"
+    }
+}
+
+
+struct ChatMessage: Decodable {
+    let id: String
+    let role: ChatRole
+    let content: String
+    let isDraft: Bool
+    let createdAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case role
+        case content
+        case isDraft = "is_draft"
+        case createdAt = "created_at"
+    }
+}
+
+enum ChatRole: String, Decodable {
+    case user
+    case assistant
+}

--- a/Logit/Logit/Network/Models/Response/UpdateAnswerResponse.swift
+++ b/Logit/Logit/Network/Models/Response/UpdateAnswerResponse.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateAnswerResponse.swift
+//  Logit
+//
+//  Created by 임재현 on 2/4/26.
+//
+
+import Foundation
+
+struct UpdateAnswerResponse: Decodable {
+    let questionId: String
+    let answer: String
+    
+    enum CodingKeys: String, CodingKey {
+        case questionId = "question_id"
+        case answer
+    }
+}

--- a/Logit/Logit/Network/Repository/ChatRepository.swift
+++ b/Logit/Logit/Network/Repository/ChatRepository.swift
@@ -13,14 +13,27 @@ protocol ChatRepository {
         projectId: String,
         request: SendMessageRequest
     ) -> AsyncThrowingStream<ChatSSEEvent, Error>
+    
+    /// 채팅 히스토리 조회
+    func getChatHistory(
+        projectId: String,
+        questionId: String,
+        cursor: String?,
+        size: Int
+    ) async throws -> ChatHistoryResponse
 }
 
 class DefaultChatRepository: ChatRepository {
     
     private let sseClient: SSEClient
+    private let networkClient: NetworkClient
     
-    init(sseClient: SSEClient) {
+    init(
+        sseClient: SSEClient,
+        networkClient: NetworkClient
+    ) {
         self.sseClient = sseClient
+        self.networkClient = networkClient
     }
     
     // 메시지 전송 (SSE 스트리밍)
@@ -31,6 +44,23 @@ class DefaultChatRepository: ChatRepository {
         return sseClient.stream(
             endpoint: ChatEndpoint.sendMessage,
             body: request
+        )
+    }
+    
+    // 채팅 히스토리 조회
+    func getChatHistory(
+        projectId: String,
+        questionId: String,
+        cursor: String? = nil,
+        size: Int = 20
+    ) async throws -> ChatHistoryResponse {
+        return try await networkClient.request(
+            endpoint: ChatEndpoint.getChatHistory(
+                questionId: questionId,
+                cursor: cursor,
+                size: size
+            ),
+            body: nil
         )
     }
 }

--- a/Logit/Logit/Network/Repository/ChatRepository.swift
+++ b/Logit/Logit/Network/Repository/ChatRepository.swift
@@ -21,6 +21,13 @@ protocol ChatRepository {
         cursor: String?,
         size: Int
     ) async throws -> ChatHistoryResponse
+    
+    /// 자기소개서 답변 업데이트
+    func updateAnswer(
+        projectId: String,
+        chatId: String,
+        request: UpdateAnswerRequest
+    ) async throws -> UpdateAnswerResponse
 }
 
 class DefaultChatRepository: ChatRepository {
@@ -61,6 +68,20 @@ class DefaultChatRepository: ChatRepository {
                 size: size
             ),
             body: nil
+        )
+    }
+    
+    // 자기소개서 답변 업데이트
+    func updateAnswer(
+        projectId: String,
+        chatId: String,
+        request: UpdateAnswerRequest
+    ) async throws -> UpdateAnswerResponse {
+        return try await networkClient.request(
+            endpoint: ChatEndpoint.updateAnswer(
+                chatId: chatId
+            ),
+            body: request
         )
     }
 }


### PR DESCRIPTION
## 🎫 What is the PR?
Chat 도메인 Network Layer 구현 (채팅 히스토리 조회 및 자기소개서 답변 업데이트 API)

## 🎫 Changes
- `ChatEndpoint`에 2개 API 추가 (`getChatHistory`, `updateAnswer`)
- `ChatHistoryResponse` DTO 구현 (채팅 히스토리 조회 응답 모델)
- `ChatMessage` DTO 구현 (개별 채팅 메시지 모델)
- `ChatRole` enum 구현 (user/assistant 역할 구분)
- `UpdateAnswerRequest` DTO 구현 (답변 업데이트 요청 모델)
- `UpdateAnswerResponse` DTO 구현 (답변 업데이트 응답 모델)
- `ChatRepository` Protocol에 2개 메서드 추가
- `DefaultChatRepository`에 2개 메서드 구현

## 🎫 Thoughts

### **Cursor 기반 페이지네이션 구현**
채팅 히스토리 조회 API는 Cursor 기반 페이지네이션을 지원합니다. Offset 기반 페이지네이션과 달리:
- 새로운 데이터가 추가되어도 중복 조회나 누락이 없음
- 서버 부하가 적음 (인덱스 기반 조회)
- 실시간성이 중요한 채팅 데이터에 적합

Query Parameter로 `cursor`(Optional)와 `size`(1~100, 기본값 20)를 받으며, 응답에 `next_cursor`와 `has_more`를 포함하여 다음 페이지 조회를 지원합니다.

### **Repository에서 두 가지 클라이언트 통합**
`DefaultChatRepository`는 SSE 스트리밍용 `SSEClient`와 일반 HTTP 요청용 `NetworkClient` 두 가지를 모두 사용합니다. 이는 관심사 분리 원칙에 어긋나지 않는 설계입니다:

**Client 레벨 분리 (완료):**
- `SSEClient`: 실시간 스트리밍 전담
- `NetworkClient`: 일반 HTTP 요청 전담

**Repository 레벨 응집 (완료):**
- Chat 도메인의 모든 기능을 `ChatRepository`에 집중
- 내부에서 어떤 클라이언트를 사용하는지는 구현 디테일
- 사용자(ViewModel)는 하나의 Repository만 알면 됨

### **초안(Draft) 개념과 답변 업데이트 플로우**
메시지 전송 시 특정 키워드("써줘", "작성해줘" 등)가 포함되면 `is_draft=true`로 마킹됩니다. 이는:
1. AI가 생성한 자기소개서 초안을 의미
2. 사용자가 검토 후 답변으로 채택 가능
3. `updateAnswer` API로 자기소개서에 반영

**플로우:**
```
1. 사용자: "경험 기반으로 자기소개서 써줘" (sendMessage)
2. AI: 스트리밍으로 답변 생성 → is_draft=true, chat_id 반환
3. 사용자: 초안 검토 후 "이걸 내 답변으로 사용"
4. 앱: updateAnswer(chat_id, answer) → 자기소개서에 반영
```

### **Size 범위 검증의 중요성**
클라이언트에서 잘못된 size 값(음수, 너무 큰 값)을 보내도 서버 에러 없이 처리하기 위해 Endpoint에서 1~100 범위로 제한합니다:
```swift
let validSize = min(max(size, 1), 100)
```
이는 방어적 프로그래밍으로, 서버의 422 에러를 사전에 방지합니다.

## 🎫 Screenshot
N/A (Network Layer 작업으로 UI 변경 없음)

## 🎫 To Reviewers

### **중점 리뷰 포인트**
1. **Cursor 페이지네이션 구현**: Query Parameter 생성 로직(`cursor`, `size`)이 올바른지 검토 부탁드립니다.
2. **Size 범위 검증**: 클라이언트 단에서 1~100으로 제한하는 것이 적절한지 의견 부탁드립니다.
3. **Repository 통합 설계**: SSEClient와 NetworkClient를 하나의 Repository에서 사용하는 구조가 적절한지 검토 부탁드립니다.
4. **초안(Draft) 개념**: `is_draft` 플래그를 기반으로 한 답변 업데이트 플로우가 명확한지 확인 부탁드립니다.
5. **DTO 구조**: `ChatHistoryResponse`에 많은 필드가 포함되어 있는데, Domain Model로 분리할 필요가 있는지 의견 부탁드립니다.

### **테스트 시 확인 사항**
- 첫 페이지 조회 (cursor 없음)
- 다음 페이지 조회 (next_cursor 사용)
- 마지막 페이지 확인 (has_more: false)
- Size 범위 검증 (음수, 0, 101 등)
- 답변 업데이트 성공/실패
- 초안 메시지를 답변으로 적용하는 플로우

## 🖥️ 주요 코드 설명

### `ChatEndpoint` - 채팅 히스토리 조회
- Cursor 기반 페이지네이션을 위한 Query Parameter 생성
- `cursor`는 Optional, `size`는 1~100 범위로 제한
```swift
case .getChatHistory(let projectId, let questionId, let cursor, let size):
    var path = "/api/v1/projects/\(projectId)/chats/\(questionId)"
    
    var queryItems: [String] = []
    
    // Size 범위 검증 (1~100)
    let validSize = min(max(size, 1), 100)
    queryItems.append("size=\(validSize)")
    
    // Cursor는 Optional
    if let cursor = cursor {
        let encodedCursor = cursor.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? cursor
        queryItems.append("cursor=\(encodedCursor)")
    }
    
    if !queryItems.isEmpty {
        path += "?" + queryItems.joined(separator: "&")
    }
    
    return path
```

**생성되는 경로 예시:**
- 첫 페이지: `/api/v1/projects/abc123/chats/question456?size=20`
- 다음 페이지: `/api/v1/projects/abc123/chats/question456?size=20&cursor=xyz789`

### `ChatHistoryResponse`
- 채팅 히스토리 전체 정보를 포함하는 응답 모델
- 프로젝트 정보, 문항 정보, 현재 답변, 채팅 메시지 목록, 페이지네이션 정보 포함
```swift
struct ChatHistoryResponse: Decodable {
    let projectName: String              // 프로젝트명
    let projectCreatedAt: String         // 프로젝트 생성일
    let questionId: String               // 문항 ID
    let question: String                 // 문항 내용
    let answer: String                   // 현재 자기소개서 답변
    let chats: [ChatMessage]             // 채팅 메시지 목록
    let experienceIds: [String]          // 참조한 경험 ID 목록
    let nextCursor: String?              // 다음 페이지 커서 (없으면 마지막 페이지)
    let hasMore: Bool                    // 추가 데이터 존재 여부
    let remainingChats: Int              // 남은 채팅 횟수
    
    enum CodingKeys: String, CodingKey {
        case projectName = "project_name"
        case projectCreatedAt = "project_created_at"
        case questionId = "question_id"
        case question
        case answer
        case chats
        case experienceIds = "experience_ids"
        case nextCursor = "next_cursor"
        case hasMore = "has_more"
        case remainingChats = "remaining_chats"
    }
}
```

### `ChatMessage` & `ChatRole`
- 개별 채팅 메시지를 나타내는 모델
- `role`로 user/assistant 구분
- `isDraft`로 초안 여부 구분
```swift
struct ChatMessage: Decodable {
    let id: String
    let role: ChatRole           // user 또는 assistant
    let content: String          // 메시지 내용
    let isDraft: Bool            // 자기소개서 초안 여부
    let createdAt: String
    
    enum CodingKeys: String, CodingKey {
        case id
        case role
        case content
        case isDraft = "is_draft"
        case createdAt = "created_at"
    }
}

enum ChatRole: String, Decodable {
    case user        // 사용자 메시지
    case assistant   // AI 응답
}
```

### `UpdateAnswerRequest` & `UpdateAnswerResponse`
- 자기소개서 답변을 업데이트하는 요청/응답 모델
- 초안 메시지를 자기소개서에 반영할 때 사용
```swift
struct UpdateAnswerRequest: Encodable {
    let questionId: String   // 어떤 문항의 답변인지
    let answer: String       // 업데이트할 답변 내용
    
    enum CodingKeys: String, CodingKey {
        case questionId = "question_id"
        case answer
    }
}

struct UpdateAnswerResponse: Decodable {
    let questionId: String   // 확인용
    let answer: String       // 업데이트된 답변
    
    enum CodingKeys: String, CodingKey {
        case questionId = "question_id"
        case answer
    }
}
```

### `DefaultChatRepository` - 완성된 구현
- SSEClient와 NetworkClient 두 가지를 모두 사용
- Chat 도메인의 3가지 기능을 모두 제공
```swift
class DefaultChatRepository: ChatRepository {
    
    private let sseClient: SSEClient        // SSE 스트리밍용
    private let networkClient: NetworkClient // 일반 HTTP용
    
    init(
        sseClient: SSEClient,
        networkClient: NetworkClient
    ) {
        self.sseClient = sseClient
        self.networkClient = networkClient
    }
    
    // 1. 메시지 전송 (SSE 스트리밍) - SSEClient 사용
    func sendMessage(
        projectId: String,
        request: SendMessageRequest
    ) -> AsyncThrowingStream<ChatSSEEvent, Error> {
        return sseClient.stream(
            endpoint: ChatEndpoint.sendMessage(projectId: projectId),
            body: request
        )
    }
    
    // 2. 채팅 히스토리 조회 (일반 GET) - NetworkClient 사용
    func getChatHistory(
        projectId: String,
        questionId: String,
        cursor: String? = nil,
        size: Int = 20
    ) async throws -> ChatHistoryResponse {
        return try await networkClient.request(
            endpoint: ChatEndpoint.getChatHistory(
                projectId: projectId,
                questionId: questionId,
                cursor: cursor,
                size: size
            ),
            body: nil
        )
    }
    
    // 3. 자기소개서 답변 업데이트 (PATCH) - NetworkClient 사용
    func updateAnswer(
        projectId: String,
        chatId: String,
        request: UpdateAnswerRequest
    ) async throws -> UpdateAnswerResponse {
        return try await networkClient.request(
            endpoint: ChatEndpoint.updateAnswer(
                projectId: projectId,
                chatId: chatId
            ),
            body: request
        )
    }
}
```

**설계 특징:**
- 각 메서드가 적절한 클라이언트 사용 (SSE vs HTTP)
- 하나의 Repository가 Chat 도메인 전체를 담당
- DI를 통해 테스트 가능성 확보

### 사용 예시 - Pagination 구현
```swift
class ChatViewModel: ObservableObject {
    @Published var messages: [ChatMessage] = []
    @Published var hasMore = false
    @Published var nextCursor: String?
    @Published var isLoadingMore = false
    
    private let repository: ChatRepository
    
    // 첫 페이지 로드
    func loadChatHistory(projectId: String, questionId: String) async {
        do {
            let response = try await repository.getChatHistory(
                projectId: projectId,
                questionId: questionId,
                cursor: nil,     // 첫 페이지
                size: 20
            )
            
            messages = response.chats
            hasMore = response.hasMore
            nextCursor = response.nextCursor
            
        } catch let error as APIError {
            print(error.localizedDescription)
        }
    }
    
    // 다음 페이지 로드
    func loadMoreMessages(projectId: String, questionId: String) async {
        guard hasMore, let cursor = nextCursor, !isLoadingMore else {
            return
        }
        
        isLoadingMore = true
        
        do {
            let response = try await repository.getChatHistory(
                projectId: projectId,
                questionId: questionId,
                cursor: cursor,  // 이전 응답의 nextCursor 사용
                size: 20
            )
            
            // 기존 메시지에 추가
            messages.append(contentsOf: response.chats)
            hasMore = response.hasMore
            nextCursor = response.nextCursor
            
        } catch let error as APIError {
            print(error.localizedDescription)
        }
        
        isLoadingMore = false
    }
}
```

### 사용 예시 - 초안 → 답변 적용 플로우
```swift
// 1. 메시지 전송으로 초안 생성
func sendMessage(...) async {
    let stream = repository.sendMessage(...)
    
    var draftChatId: String?
    var draftContent = ""
    
    for try await event in stream {
        switch event {
        case .content(let text):
            draftContent += text
            
        case .done(let chatId, let isDraft, _):
            if isDraft {
                // 초안이 생성됨
                draftChatId = chatId
                // 사용자에게 "답변으로 적용" 버튼 제공
            }
            
        case .error(let message):
            // 에러 처리
        }
    }
}

// 2. 사용자가 "답변으로 적용" 버튼 클릭
func applyDraftToAnswer(
    projectId: String,
    chatId: String,
    questionId: String,
    answer: String
) async {
    let request = UpdateAnswerRequest(
        questionId: questionId,
        answer: answer
    )
    
    do {
        let response = try await repository.updateAnswer(
            projectId: projectId,
            chatId: chatId,
            request: request
        )
        
        print("답변 업데이트 완료: \(response.answer)")
        
    } catch let error as APIError {
        print(error.localizedDescription)
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #29 