### PR TITLE
[feat] 프로젝트 생성 플로우 완성 및 Workspace 화면 진입 구현

### DIFF
--- a/Logit/Logit/AppState.swift
+++ b/Logit/Logit/AppState.swift
@@ -13,6 +13,7 @@ class AppState: ObservableObject {
     @Published var isShowingSignUpSheet: Bool = false
     @Published var isShowingAddFlow: Bool = false
     @Published var isShowingSettings = false
+    @Published var selectedProjectId: String?
     
     enum AppPhase {
         case splash
@@ -100,5 +101,9 @@ class AppState: ObservableObject {
     
     func startSettings() {
         isShowingSettings = true
+    }
+    
+    func openWorkspace(projectId: String) {
+        selectedProjectId = projectId
     }
 }

--- a/Logit/Logit/Features/AddFlowCoordinator.swift
+++ b/Logit/Logit/Features/AddFlowCoordinator.swift
@@ -20,7 +20,7 @@ struct AddFlowCoordinator: View {
                     
                 case .workspace(let projectId, let questions):
                     CoverLetterWorkspaceView(
-                        questions: questions, projectId: projectId
+                        projectId: projectId, questions: questions
                     )
                 }
             }

--- a/Logit/Logit/Features/AddFlowCoordinator.swift
+++ b/Logit/Logit/Features/AddFlowCoordinator.swift
@@ -13,11 +13,20 @@ struct AddFlowCoordinator: View {
     
     var body: some View {
         NavigationStack(path: $viewModel.path) {
-            
-            ApplicationInfoView()
-                .navigationDestination(for: AddFlowRoute.self) { route in
-                    viewModel.destination(for: route)
+            Group {
+                switch viewModel.rootScreen {
+                case .applicationInfo:
+                    ApplicationInfoView()
+                    
+                case .workspace(let projectId, let questions):
+                    CoverLetterWorkspaceView(
+                        questions: questions, projectId: projectId
+                    )
                 }
+            }
+            .navigationDestination(for: AddFlowRoute.self) { route in
+                viewModel.destination(for: route)
+            }
         }
         .navigationBarHidden(true)
         .environmentObject(viewModel)

--- a/Logit/Logit/Features/AddFlowRoute.swift
+++ b/Logit/Logit/Features/AddFlowRoute.swift
@@ -10,5 +10,5 @@ import Foundation
 enum AddFlowRoute: Hashable {
     case applicationInfo // 지원 정보 입력
     case coverLetterQuestions // 자소서 문항
-    case workspace([QuestionItem]) // 상세문항 (q1,q2...)
+    case workspace(questions: [QuestionItem], projectId: String) // 상세문항 (q1,q2...)
 }

--- a/Logit/Logit/Features/AddFlowRoute.swift
+++ b/Logit/Logit/Features/AddFlowRoute.swift
@@ -10,5 +10,5 @@ import Foundation
 enum AddFlowRoute: Hashable {
     case applicationInfo // 지원 정보 입력
     case coverLetterQuestions // 자소서 문항
-    case workspace(questions: [QuestionItem], projectId: String) // 상세문항 (q1,q2...)
+   // case workspace(questions: [QuestionItem], projectId: String) // 상세문항 (q1,q2...)
 }

--- a/Logit/Logit/Features/AddFlowViewModel.swift
+++ b/Logit/Logit/Features/AddFlowViewModel.swift
@@ -11,6 +11,25 @@ import SwiftUI
 class AddFlowViewModel: ObservableObject {
     @Published var path = NavigationPath()
     
+    
+    // Step 1: 지원기업 정보
+    @Published var companyName: String = ""  // 기업명
+    @Published var jobPosition: String = ""  // 직무명
+    @Published var recruitNotice: String = ""  // 채용 공고
+    @Published var companyTalent: String = ""  // 기업 인재상
+    @Published var dueDate: String?
+    
+    
+    @Published var questions: [QuestionItem] = [QuestionItem()]
+    
+    private let projectRepository: ProjectRepository
+    
+    init(projectRepository: ProjectRepository = DefaultProjectRepository()) {
+        self.projectRepository = projectRepository
+    }
+       
+    
+    
     // Navigation 함수들
     
     func navigateToCoverLetterQuestions() {
@@ -20,16 +39,60 @@ class AddFlowViewModel: ObservableObject {
     func navigateToApplicationInfo() {
         path.append(AddFlowRoute.applicationInfo)
     }
-    
-    func navigateToCoverLetterWorkspace(questions: [QuestionItem]) {
-        path.append(AddFlowRoute.workspace(questions))
-    }
-    
     func navigateBack() {
         if !path.isEmpty {
             path.removeLast()
         }
     }
+    
+    func createProject() async {
+        // CreateProjectRequest 생성
+        let request = CreateProjectRequest(
+            company: companyName,
+            companyTalent: companyTalent,
+            dueDate: nil,
+            jobPosition: jobPosition,
+            questions: questions.map { question in
+                QuestionRequest(
+                    maxLength: Int(question.characterLimit) ?? 0,
+                    question: question.title
+                )
+            },
+            recruitNotice: recruitNotice
+        )
+        
+        print("프로젝트 생성 요청")
+        print("기업명: \(companyName)")
+        print("직무명: \(jobPosition)")
+        print("채용 공고: \(recruitNotice)")
+        print("기업 인재상: \(companyTalent)")
+        print("마감일: \(dueDate)")
+        print("문항 개수: \(questions.count)")
+        questions.enumerated().forEach { index, question in
+            print("  문항 \(index + 1): \(question.title) (\(question.characterLimit)자)")
+        }
+        
+        do {
+            let response = try await projectRepository.createProject(request: request)
+            print(" 프로젝트 생성 성공!")
+            print("응답: \(response)")
+            print("프로젝트 ID: \(response.id)")
+            
+            // TODO: 성공 후 처리 (예: Workspace로 이동)
+            path.append(AddFlowRoute.workspace(
+                           questions: questions,
+                           projectId: response.id
+                       ))
+            
+        } catch {
+            print(" 프로젝트 생성 실패: \(error)")
+            
+            if let apiError = error as? APIError {
+                print("API Error: \(apiError.localizedDescription)")
+            }
+        }
+    }
+    
     
     // View 생성
     @ViewBuilder
@@ -42,8 +105,11 @@ class AddFlowViewModel: ObservableObject {
         case .coverLetterQuestions:
             CoverLetterQuestionsView()
             
-        case .workspace(let questions):
-            CoverLetterWorkspaceView(questions: questions)
+        case .workspace(let questions, let projectId):
+               CoverLetterWorkspaceView(
+                   questions: questions,
+                   projectId: projectId
+               )
         }
     }
 }

--- a/Logit/Logit/Features/AddFlowViewModel.swift
+++ b/Logit/Logit/Features/AddFlowViewModel.swift
@@ -10,6 +10,12 @@ import SwiftUI
 @MainActor
 class AddFlowViewModel: ObservableObject {
     @Published var path = NavigationPath()
+    @Published var rootScreen: RootScreen = .applicationInfo
+    
+    enum RootScreen {
+        case applicationInfo
+        case workspace(projectId: String, questions: [QuestionItem])
+    }
     
     
     // Step 1: 지원기업 정보
@@ -79,10 +85,10 @@ class AddFlowViewModel: ObservableObject {
             print("프로젝트 ID: \(response.id)")
             
             // TODO: 성공 후 처리 (예: Workspace로 이동)
-            path.append(AddFlowRoute.workspace(
-                           questions: questions,
-                           projectId: response.id
-                       ))
+            rootScreen = .workspace(projectId: response.id, questions: questions)
+                       
+            //  스택 초기화
+            path = NavigationPath()
             
         } catch {
             print(" 프로젝트 생성 실패: \(error)")

--- a/Logit/Logit/Features/AddFlowViewModel.swift
+++ b/Logit/Logit/Features/AddFlowViewModel.swift
@@ -86,7 +86,7 @@ class AddFlowViewModel: ObservableObject {
             print("프로젝트 ID: \(response.id)")
             
             print("문항 등록 시작")
-            try await createQuestionsInParallel(projectId: response.id)
+          //  try await createQuestionsInParallel(projectId: response.id)
             print("모든 문항 등록 완료!")
             
             // TODO: 성공 후 처리 (예: Workspace로 이동)
@@ -148,11 +148,10 @@ class AddFlowViewModel: ObservableObject {
         case .coverLetterQuestions:
             CoverLetterQuestionsView()
             
-        case .workspace(let questions, let projectId):
-               CoverLetterWorkspaceView(
-                   questions: questions,
-                   projectId: projectId
-               )
+//        case .workspace(let questions, let projectId):
+//               CoverLetterWorkspaceView(
+//                projectId: projectId, questions: questions
+//               )
         }
     }
 }

--- a/Logit/Logit/Features/ApplicationInfoView.swift
+++ b/Logit/Logit/Features/ApplicationInfoView.swift
@@ -44,7 +44,7 @@ struct ApplicationInfoView: View {
                             placeholder: "예) 로짓 컴퍼니",
                             isRequired: true,
                             maxLength: 100,
-                            text: $companyName
+                            text: $viewModel.companyName
                         )
                         
                         InputFieldView(
@@ -52,7 +52,7 @@ struct ApplicationInfoView: View {
                             placeholder: "예) 프로덕트 디자이너",
                             isRequired: true,
                             maxLength: 100,
-                            text: $position
+                            text: $viewModel.jobPosition
                         )
                         
                         InputFieldView(
@@ -61,7 +61,7 @@ struct ApplicationInfoView: View {
                             isRequired: true,
                             maxLength: 3000,
                             largeHeight: 90,
-                            text: $department
+                            text: $viewModel.recruitNotice
                         )
                         
                         InputFieldView(
@@ -69,7 +69,7 @@ struct ApplicationInfoView: View {
                             placeholder: "기업의 인재상이나 핵심가치를 입력하세요",
                             isRequired: false,
                             maxLength: 1000,
-                            text: $experienceLevel
+                            text: $viewModel.companyTalent
                         )
                     }
                     .padding(.top, 24)
@@ -101,7 +101,9 @@ struct ApplicationInfoView: View {
     }
     
     private var isFormValid: Bool {
-        !companyName.isEmpty && !position.isEmpty && !department.isEmpty
+        !viewModel.companyName.isEmpty &&
+        !viewModel.jobPosition.isEmpty &&
+        !viewModel.recruitNotice.isEmpty
     }
 }
 

--- a/Logit/Logit/Features/CoverLetterQuestionsView.swift
+++ b/Logit/Logit/Features/CoverLetterQuestionsView.swift
@@ -16,10 +16,10 @@ struct CoverLetterQuestionsView: View {
     private let maxQuestionsCount = 5 // 최대 문항 개수
     
     private var isFormValid: Bool {
-         questions.allSatisfy { question in
-             !question.title.isEmpty && !question.characterLimit.isEmpty
-         }
-     }
+        viewModel.questions.allSatisfy { question in
+            !question.title.isEmpty && !question.characterLimit.isEmpty
+        }
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -48,12 +48,12 @@ struct CoverLetterQuestionsView: View {
                             QuestionInputRow(
                                 questionNumber: index + 1,
                                 questionTitle: Binding(
-                                    get: { questions[index].title },
-                                    set: { questions[index].title = $0 }
+                                    get: { viewModel.questions[index].title },
+                                    set: { viewModel.questions[index].title = $0 }
                                 ),
                                 characterLimit: Binding(
-                                    get: { questions[index].characterLimit },
-                                    set: { questions[index].characterLimit = $0 }
+                                    get: { viewModel.questions[index].characterLimit },
+                                    set: { viewModel.questions[index].characterLimit = $0 }
                                 )
                             )
                         }
@@ -61,7 +61,7 @@ struct CoverLetterQuestionsView: View {
                         // 추가하기 버튼 (최대 개수 미만일 때만 표시)
                         if questions.count < maxQuestionsCount {
                             Button {
-                                questions.append(QuestionItem())
+                                viewModel.questions.append(QuestionItem())
                             } label: {
                                 HStack(spacing: 8) {
                                     Image("plus_selected")
@@ -89,7 +89,9 @@ struct CoverLetterQuestionsView: View {
                     
                     Button {
                         // TODO: 완료 액션
-                        viewModel.navigateToCoverLetterWorkspace(questions: questions)
+                        Task {
+                            await viewModel.createProject()
+                        }
                     } label: {
                         Text("프로젝트 생성")
                             .typo(.bold_18)

--- a/Logit/Logit/Features/CoverLetterQuestionsView.swift
+++ b/Logit/Logit/Features/CoverLetterQuestionsView.swift
@@ -11,8 +11,6 @@ struct CoverLetterQuestionsView: View {
     @EnvironmentObject var viewModel: AddFlowViewModel
     @Environment(\.dismiss) var dismiss
     
-    @State private var questions: [QuestionItem] = [QuestionItem()]
-    
     private let maxQuestionsCount = 5 // 최대 문항 개수
     
     private var isFormValid: Bool {
@@ -44,7 +42,7 @@ struct CoverLetterQuestionsView: View {
                         .padding(.top, 3)
                     
                     VStack(spacing: 20) {
-                        ForEach(Array(questions.enumerated()), id: \.element.id) { index, question in
+                        ForEach(Array(viewModel.questions.enumerated()), id: \.element.id) { index, question in
                             QuestionInputRow(
                                 questionNumber: index + 1,
                                 questionTitle: Binding(
@@ -59,7 +57,7 @@ struct CoverLetterQuestionsView: View {
                         }
                         
                         // 추가하기 버튼 (최대 개수 미만일 때만 표시)
-                        if questions.count < maxQuestionsCount {
+                        if viewModel.questions.count < maxQuestionsCount {
                             Button {
                                 viewModel.questions.append(QuestionItem())
                             } label: {

--- a/Logit/Logit/Features/CoverLetterWorkspaceView.swift
+++ b/Logit/Logit/Features/CoverLetterWorkspaceView.swift
@@ -93,6 +93,9 @@ struct CoverLetterWorkspaceView: View {
                 }
             )
         }
+        .task {
+          //  await viewModel.fetchProjectDetail()
+        }
         .dismissKeyboardOnTap()
         .navigationBarHidden(true)
         .sheet(isPresented: $showExperienceSelection) {

--- a/Logit/Logit/Features/CoverLetterWorkspaceView.swift
+++ b/Logit/Logit/Features/CoverLetterWorkspaceView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CoverLetterWorkspaceView: View {
     @Environment(\.dismiss) var dismiss
     let questions: [QuestionItem]
+    let projectId: String
     @State private var selectedQuestionIndex: Int = 0
     @State private var selectedView: ContentType = .chat
     @State private var hasData: Bool = false
@@ -73,6 +74,7 @@ struct CoverLetterWorkspaceView: View {
                     } else {
                         EmptyWorkspaceView {
                             print("경험 선택 버튼 클릭")
+                            print("현재 프로젝트 ID: \(projectId)")
                             showExperienceSelection = true
                         }
                     }
@@ -84,6 +86,7 @@ struct CoverLetterWorkspaceView: View {
             ChatInputBar(
                 onSend: { message in
                     print("전송: \(message)")
+                    print("프로젝트 ID: \(projectId)")
                 },
                 onAttachmentTapped: {
                     showExperienceSelection = true 

--- a/Logit/Logit/Features/WorkspaceViewModel.swift
+++ b/Logit/Logit/Features/WorkspaceViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  WorkspaceViewModel.swift
+//  Logit
+//
+//  Created by 임재현 on 2/6/26.
+//
+
+import Foundation
+
+@MainActor
+class WorkspaceViewModel: ObservableObject {
+    @Published var projectDetail: ProjectDetailResponse?
+    @Published var questionList: [QuestionResponse] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    
+    private let projectRepository: ProjectRepository
+    private let questionRepository: QuestionRepository
+    let projectId: String
+    
+    init(
+        projectId: String,
+        projectRepository: ProjectRepository = DefaultProjectRepository(),
+        questionRepository: QuestionRepository = DefaultQuestionRepository()
+    ) {
+        self.projectId = projectId
+        self.projectRepository = projectRepository
+        self.questionRepository = questionRepository
+    }
+    
+
+    func fetchProjectDetail() async {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let detail = try await projectRepository.getProjectDetail(projectId: projectId)
+            projectDetail = detail
+            print(" 프로젝트 상세 조회 성공: \(detail.company) - \(detail.jobPosition)")
+            
+        } catch {
+            print("프로젝트 상세 조회 실패: \(error)")
+            errorMessage = "프로젝트 정보를 불러올 수 없습니다."
+            
+            if let apiError = error as? APIError {
+                print("API Error: \(apiError.localizedDescription)")
+            }
+        }
+        
+        isLoading = false
+    }
+    
+    func fetchQuestionList() async {
+        do {
+            let questions = try await questionRepository.getQuestionList(projectId: projectId)
+            questionList = questions
+            print("문항 목록 조회 성공: \(questions.count)개")
+            questions.enumerated().forEach { index, question in
+                print("  Q\(index + 1): \(question.question) (ID: \(question.id))")
+            }
+            
+        } catch {
+            print("문항 목록 조회 실패: \(error)")
+            errorMessage = "문항 목록을 불러올 수 없습니다."
+            
+            if let apiError = error as? APIError {
+                print("API Error: \(apiError.localizedDescription)")
+            }
+        }
+    }
+    
+    var navigationTitle: String {
+        guard let detail = projectDetail else {
+            return "프로젝트"
+        }
+        return "\(detail.company) - \(detail.jobPosition)"
+    }
+}

--- a/Logit/Logit/Home/HomeView.swift
+++ b/Logit/Logit/Home/HomeView.swift
@@ -9,20 +9,31 @@ import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject var appState: AppState
-    @State private var hasProjects: Bool = false
+    @StateObject private var viewModel = HomeViewModel()
     
     var body: some View {
         VStack(spacing: 0) {
-            
             HomeHeaderView()
+            
             ExperienceTypeSection()
                 .padding(.top, 22.adjustedLayout)
             
-            ProjectListSection(hasProjects: hasProjects)
-                .padding(.top, 43.adjustedLayout)
+            ProjectListSection(
+                hasProjects: viewModel.hasProjects,
+                projects: viewModel.projects,
+                isLoading: viewModel.isLoading
+            )
+            .padding(.top, 43.adjustedLayout)
             
             Spacer()
-            
+        }
+        .task {
+            // 화면이 나타날 때 프로젝트 목록 조회
+            await viewModel.fetchProjects()
+        }
+        .refreshable {
+            // Pull to refresh
+            await viewModel.fetchProjects()
         }
     }
 }

--- a/Logit/Logit/Home/HomeViewModel.swift
+++ b/Logit/Logit/Home/HomeViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  HomeViewModel.swift
+//  Logit
+//
+//  Created by 임재현 on 2/5/26.
+//
+
+import Foundation
+
+@MainActor
+class HomeViewModel: ObservableObject {
+    @Published var projects: [ProjectListItemResponse] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    
+    private let projectRepository: ProjectRepository
+    
+    init(projectRepository: ProjectRepository = DefaultProjectRepository()) {
+        self.projectRepository = projectRepository
+    }
+    
+    func fetchProjects() async {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            // 전체 프로젝트 가져오기 (skip: 0, limit: 100)
+            let fetchedProjects = try await projectRepository.getProjectList(
+                skip: 0,
+                limit: 100
+            )
+            
+            projects = fetchedProjects
+            print(" 프로젝트 목록 조회 성공: \(fetchedProjects.count)개")
+            
+        } catch {
+            print(" 프로젝트 목록 조회 실패: \(error)")
+            errorMessage = "프로젝트 목록을 불러올 수 없습니다."
+            
+            if let apiError = error as? APIError {
+                print("API Error: \(apiError.localizedDescription)")
+            }
+        }
+        
+        isLoading = false
+    }
+    
+    var hasProjects: Bool {
+        !projects.isEmpty
+    }
+}

--- a/Logit/Logit/Home/ProjectListSection.swift
+++ b/Logit/Logit/Home/ProjectListSection.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ProjectListSection: View {
     @EnvironmentObject var appState: AppState
     let hasProjects: Bool
+    let projects: [ProjectListItemResponse]
+    let isLoading: Bool
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8.adjustedLayout) {
@@ -24,8 +26,13 @@ struct ProjectListSection: View {
             .padding(.horizontal, 20.adjustedLayout)
             
             // 컨텐츠
-            if hasProjects {
-                ProjectListView()
+            if isLoading {
+                // 로딩 중
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.vertical, 60.adjustedLayout)
+            } else if hasProjects {
+                ProjectListView(projects: projects)
                     .padding(.top, 8.adjustedLayout)
             } else {
                 ProjectEmptyView()
@@ -72,30 +79,26 @@ struct ProjectEmptyView: View {
 }
 
 struct ProjectListView: View {
-    // 나중에 실제 데이터로 교체
-    let mockProjects = [
-        ("프로젝트 1", "2024.01.15"),
-        ("프로젝트 2", "2023.12.20"),
-        ("프로젝트 3", "2023.11.05"),
-        ("프로젝트 4", "2023.11.05"),
-        ("프로젝트 5", "2023.11.05")
-    ]
+    let projects: [ProjectListItemResponse]
     
     var body: some View {
-        VStack(spacing: 0) {
-            ForEach(mockProjects.indices, id: \.self) { index in
-                ProjectCardCell(
-                    title: mockProjects[index].0,
-                    date: mockProjects[index].1
-                )
-                
-                // Divider (마지막 셀 제외)
-                if index < mockProjects.count - 1 {
-                    Divider()
-                        .background(Color.gray100)
-                        .padding(.horizontal, 20.adjustedLayout)
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(projects.indices, id: \.self) { index in
+                    ProjectCardCell(
+                        title: projects[index].company,
+                        date: projects[index].updatedAt.toDateString(format: "yyyy.MM.dd")
+                    )
+                    
+                    if index < projects.count - 1 {
+                        Divider()
+                            .background(Color.gray100)
+                            .padding(.horizontal, 20.adjustedLayout)
+                    }
                 }
             }
+            .foregroundStyle(.red)
+            .padding(.bottom, (49 + 20).adjustedLayout)
         }
     }
 }

--- a/Logit/Logit/Home/ProjectListSection.swift
+++ b/Logit/Logit/Home/ProjectListSection.swift
@@ -86,8 +86,7 @@ struct ProjectListView: View {
             VStack(spacing: 0) {
                 ForEach(projects.indices, id: \.self) { index in
                     ProjectCardCell(
-                        title: projects[index].company,
-                        date: projects[index].updatedAt.toDateString(format: "yyyy.MM.dd")
+                        project: projects[index]
                     )
                     
                     if index < projects.count - 1 {
@@ -97,25 +96,24 @@ struct ProjectListView: View {
                     }
                 }
             }
-            .foregroundStyle(.red)
             .padding(.bottom, (49 + 20).adjustedLayout)
         }
     }
 }
 
 struct ProjectCardCell: View {
-    let title: String
-    let date: String
+    @EnvironmentObject var appState: AppState
+    let project: ProjectListItemResponse
     
     var body: some View {
         HStack(spacing: 12.adjustedLayout) {
-            // 세로 막대기 (태그)
+            // 세로 막대기
             RoundedRectangle(cornerRadius: 2.adjustedLayout)
                 .fill(.primary70)
                 .frame(width: 3.adjustedWidth, height: 24.adjustedHeight)
             
             // 타이틀
-            Text(title)
+            Text(project.company)
                 .typo(.medium_15)
                 .foregroundStyle(.black)
                 .lineLimit(1)
@@ -123,12 +121,16 @@ struct ProjectCardCell: View {
             Spacer()
             
             // 날짜
-            Text(date)
+            Text(project.updatedAt.toDateString(format: "yyyy.MM.dd"))
                 .typo(.regular_14_140)
                 .foregroundStyle(.gray100)
         }
         .padding(.horizontal, 20.adjustedLayout)
         .padding(.vertical, 17.5.adjustedLayout)
         .background(Color.white)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            appState.openWorkspace(projectId: project.id)
+        }
     }
 }

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -49,6 +49,11 @@ struct MainTabView: View {
         .fullScreenCover(isPresented: $appState.isShowingAddFlow) {
             AddFlowCoordinator()
         }
+        .fullScreenCover(item: $appState.selectedProjectId) { projectId in
+            CoverLetterWorkspaceView(
+                questions: [], projectId: projectId
+            )
+        }
         .fullScreenCover(isPresented: $appState.isShowingSettings) {
             SettingsView()
         }

--- a/Logit/Logit/MainTabView.swift
+++ b/Logit/Logit/MainTabView.swift
@@ -51,7 +51,7 @@ struct MainTabView: View {
         }
         .fullScreenCover(item: $appState.selectedProjectId) { projectId in
             CoverLetterWorkspaceView(
-                questions: [], projectId: projectId
+                projectId: projectId, questions: []
             )
         }
         .fullScreenCover(isPresented: $appState.isShowingSettings) {

--- a/Logit/Logit/Network/Core/EndPoint/ProjectEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ProjectEndpoint.swift
@@ -21,7 +21,7 @@ enum ProjectEndpoint: Endpoint {
         case .getProjectList(let skip, let limit):
             let skipValue = max(skip, 0) 
             let limitValue = max(1, min(limit, 200))
-            return "/api/v1/projects?skip=\(skipValue)&limit=\(limitValue)"
+            return "/api/v1/projects/?skip=\(skipValue)&limit=\(limitValue)"
         case .getProjectDetail(let id):
             return "/api/v1/projects/\(id)"
         case .updateProject(let id):

--- a/Logit/Logit/Network/Core/EndPoint/ProjectEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/ProjectEndpoint.swift
@@ -17,7 +17,7 @@ enum ProjectEndpoint: Endpoint {
     var path: String {
         switch self {
         case .createProject:
-            return "/api/v1/projects"
+            return "/api/v1/projects/"
         case .getProjectList(let skip, let limit):
             let skipValue = max(skip, 0) 
             let limitValue = max(1, min(limit, 200))

--- a/Logit/Logit/Network/Core/EndPoint/QuestionEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/QuestionEndpoint.swift
@@ -20,7 +20,7 @@ enum QuestionEndpoint: Endpoint {
             return "/api/v1/projects/\(projectId)/questions/"
             
         case .getQuestionList(let projectId):
-            return "/api/v1/projects/\(projectId)/questions"
+            return "/api/v1/projects/\(projectId)/questions/"
             
         case .getQuestionDetail(let projectId, let questionId):
             return "/api/v1/projects/\(projectId)/questions/\(questionId)"

--- a/Logit/Logit/Network/Core/EndPoint/QuestionEndpoint.swift
+++ b/Logit/Logit/Network/Core/EndPoint/QuestionEndpoint.swift
@@ -17,7 +17,7 @@ enum QuestionEndpoint: Endpoint {
     var path: String {
         switch self {
         case .createQuestion(let projectId):
-            return "/api/v1/projects/\(projectId)/questions"
+            return "/api/v1/projects/\(projectId)/questions/"
             
         case .getQuestionList(let projectId):
             return "/api/v1/projects/\(projectId)/questions"

--- a/Logit/Logit/Network/Models/Request/CreateProjectRequest.swift
+++ b/Logit/Logit/Network/Models/Request/CreateProjectRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 struct CreateProjectRequest: Encodable {
     let company: String
     let companyTalent: String
-    let dueDate: String
+    let dueDate: String?
     let jobPosition: String
     let questions: [QuestionRequest]
     let recruitNotice: String

--- a/Logit/Logit/Network/Models/Response/ProjectDetailResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ProjectDetailResponse.swift
@@ -12,7 +12,7 @@ struct ProjectDetailResponse: Decodable {
     let company: String
     let jobPosition: String
     let recruitNotice: String
-    let dueDate: String
+    let dueDate: String?
     let userId: String
     let createdAt: String
     let updatedAt: String

--- a/Logit/Logit/Network/Models/Response/ProjectListItemResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ProjectListItemResponse.swift
@@ -12,7 +12,7 @@ struct ProjectListItemResponse: Decodable {
     let company: String
     let jobPosition: String
     let updatedAt: String
-    let questionId: String
+    let questionId: String?
     
     enum CodingKeys: String, CodingKey {
         case id

--- a/Logit/Logit/Network/Models/Response/ProjectResponse.swift
+++ b/Logit/Logit/Network/Models/Response/ProjectResponse.swift
@@ -12,7 +12,7 @@ struct ProjectResponse: Decodable {
     let company: String
     let jobPosition: String
     let recruitNotice: String
-    let dueDate: String
+    let dueDate: String?
     let userId: String
     let createdAt: String
     let updatedAt: String

--- a/Logit/Logit/Network/Models/Response/QuestionResponse.swift
+++ b/Logit/Logit/Network/Models/Response/QuestionResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 struct QuestionResponse: Decodable {
     let answer: String?
     let id: String
-    let maxLength: Int
+    let maxLength: Int?
     let question: String
     
     enum CodingKeys: String, CodingKey {

--- a/Logit/Logit/Network/Models/Response/QuestionResponse.swift
+++ b/Logit/Logit/Network/Models/Response/QuestionResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct QuestionResponse: Decodable {
-    let answer: String
+    let answer: String?
     let id: String
     let maxLength: Int
     let question: String

--- a/Logit/Logit/Network/Repository/QuestionReposiotry.swift
+++ b/Logit/Logit/Network/Repository/QuestionReposiotry.swift
@@ -24,7 +24,7 @@ class DefaultQuestionRepository: QuestionRepository {
     
     private let networkClient: NetworkClient
     
-    init(networkClient: NetworkClient) {
+    init(networkClient: NetworkClient = DefaultNetworkClient()) { 
         self.networkClient = networkClient
     }
     

--- a/Logit/Logit/Resources/Shared/Extensions/String+.swift
+++ b/Logit/Logit/Resources/Shared/Extensions/String+.swift
@@ -55,3 +55,7 @@ extension String {
            return date.toString(format: format)
        }
 }
+
+extension String: @retroactive Identifiable {
+    public var id: String { self }
+}

--- a/Logit/Logit/Resources/Shared/Extensions/String+.swift
+++ b/Logit/Logit/Resources/Shared/Extensions/String+.swift
@@ -39,4 +39,19 @@ extension String {
     var onlyNumbers: String {
         self.filter { $0.isNumber }
     }
+    
+    /// ISO 8601 문자열을 Date로 변환
+       func toDate() -> Date? {
+           let formatter = ISO8601DateFormatter()
+           //  밀리초 있어도/없어도 둘 다 처리
+           return formatter.date(from: self)
+       }
+       
+       /// ISO 8601 문자열을 원하는 형식의 날짜 문자열로 변환
+       func toDateString(format: String = "yyyy.MM.dd") -> String {
+           guard let date = self.toDate() else {
+               return self  // 변환 실패 시 원본 반환
+           }
+           return date.toString(format: format)
+       }
 }


### PR DESCRIPTION
## 🎫 What is the PR?
프로젝트 생성 플로우 완성 및 Workspace 화면 진입 구현

## 🎫 Changes
- 프로젝트 생성 API 연동 (프로젝트 + 문항 동시 생성)
- 프로젝트 목록 조회 및 UI 바인딩
- Workspace 화면 진입 플로우 구현 (AddFlow / HomeView)
- 문항 목록 조회 및 QuestionTabBar 동적 생성
- NavigationStack 기반 화면 전환 관리
- API 중복 호출 방지 로직 구현

## 🎫 Thoughts

### 1. rootScreen 방식의 네비게이션 관리
프로젝트 생성 후 Workspace로 이동 시, 기존 네비게이션 스택을 초기화하고 새로운 루트 화면으로 전환하는 패턴을 구현했습니다. 
- `rootScreen` enum을 통해 `.applicationInfo` ↔ `.workspace` 전환
- 생성 완료 후 `path` 초기화로 뒤로가기 시 MainTab으로 복귀
- 네비게이션 스택 관리의 명확성 확보

### 2. API 중복 호출 문제 해결
View 생명주기와 State 변경으로 인한 API 중복 호출 이슈가 있었습니다.
- 초기: `.task` 사용 시 View 재생성마다 취소/재시작 발생
- 해결: `.onAppear` + `hasLoadedData` 플래그 조합으로 단 1회만 실행 보장
- Task cancellation 에러 제거

### 3. 프로젝트 생성 API 설계 이해
초기에는 "프로젝트 생성 → 각 문항 개별 등록"으로 구현했으나, 실제 API는 프로젝트 생성 시 문항을 함께 받아 일괄 생성하는 방식이었습니다.
- `CreateProjectRequest`의 `questions` 배열에 문항 포함
- 불필요한 `createQuestionsInParallel()` 함수 제거
- API 스펙에 대한 정확한 이해의 중요성 학습

### 4. 데이터 흐름 설계
- AddFlow: 입력한 문항 데이터를 임시로 전달
- HomeView: projectId만 전달 후 Workspace에서 API 조회
- 두 진입 경로의 차이를 고려한 유연한 설계

## 🎫 Screenshot
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| 프로젝트 생성 플로우 | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |
| 프로젝트 목록 조회 | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |
| Workspace 진입 | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers
- rootScreen 패턴의 적절성에 대한 궁금증..
- API 에러 처리 로직이 충분한지 확인..
- `.onAppear` vs `.task` 선택에 대하여 생각해볼것
- 하다보니 Questions API 연동까지 완려해서 feat/#38은 건너뛸 예정

## 🖥️ 주요 코드 설명

### `AddFlowViewModel`
프로젝트 생성 및 네비게이션 관리
```swift
func createProject() async {
    let request = CreateProjectRequest(
        company: companyName,
        companyTalent: companyTalent,
        dueDate: nil,
        jobPosition: jobPosition,
        questions: questions.map { question in
            QuestionRequest(
                maxLength: Int(question.characterLimit) ?? 0,
                question: question.title
            )
        },
        recruitNotice: recruitNotice
    )
    
    do {
        let response = try await projectRepository.createProject(request: request)
        
        // 프로젝트 생성 시 문항도 함께 생성됨 (별도 API 호출 불필요)
        
        // NavigationPath 초기화 (기존 스택 제거)
        path = NavigationPath()
        
        // rootScreen 전환 (ApplicationInfo → Workspace)
        // 이제 Workspace가 새로운 루트 화면이 되어 뒤로가기 시 MainTab으로 복귀
        rootScreen = .workspace(
            projectId: response.id,
            questions: questions
        )
        
    } catch {
        print("❌ 프로젝트 생성 실패: \(error)")
    }
}
```

### `AddFlowCoordinator`
rootScreen 기반 동적 루트 화면 전환
```swift
struct AddFlowCoordinator: View {
    @StateObject private var viewModel = AddFlowViewModel()
    
    var body: some View {
        NavigationStack(path: $viewModel.path) {
            Group {
                //  rootScreen에 따라 루트 화면 동적 변경
                switch viewModel.rootScreen {
                case .applicationInfo:
                    ApplicationInfoView()  // 초기 루트
                    
                case .workspace(let projectId, let questions):
                    CoverLetterWorkspaceView(
                        projectId: projectId,
                        questions: questions
                    )  // 프로젝트 생성 후 새로운 루트
                }
            }
            .navigationDestination(for: AddFlowRoute.self) { route in
                viewModel.destination(for: route)
            }
        }
        .navigationBarHidden(true)
        .environmentObject(viewModel)
    }
}

//  RootScreen enum으로 루트 화면 상태 관리
enum RootScreen {
    case applicationInfo
    case workspace(projectId: String, questions: [QuestionItem])
}
```

**동작 흐름:**
```
1. 초기 상태
   rootScreen = .applicationInfo
   path = []
   
2. "다음" 버튼 → Questions 화면
   rootScreen = .applicationInfo (유지)
   path = [.coverLetterQuestions]
   
3. "프로젝트 생성" 성공
   path = []  // 스택 초기화
   rootScreen = .workspace(...)  // 루트 교체
   
4. Workspace에서 뒤로가기
   path가 비어있어 더 갈 곳 없음
   → Coordinator dismiss
   → MainTab 복귀
```

### `WorkspaceViewModel`
프로젝트 상세 및 문항 목록 조회
```swift
@MainActor
class WorkspaceViewModel: ObservableObject {
    @Published var projectDetail: ProjectDetailResponse?
    @Published var questionList: [QuestionResponse] = []
    @Published var isLoading: Bool = false
    
    func fetchProjectDetail() async {
        // 프로젝트 상세 정보 조회 (회사명, 직무명)
    }
    
    func fetchQuestionList() async {
        // 문항 목록 조회 (QuestionTabBar 생성용)
    }
    
    var navigationTitle: String {
        guard let detail = projectDetail else { return "프로젝트" }
        return "\(detail.company) - \(detail.jobPosition)"
    }
}
```

### `CoverLetterWorkspaceView`
API 중복 호출 방지
```swift
struct CoverLetterWorkspaceView: View {
    @State private var hasLoadedData = false
    
    var body: some View {
        VStack {
            // UI
        }
        .onAppear {
            // View 재생성 시에도 단 1회만 실행
            guard !hasLoadedData else {
                print("이미 데이터 로드됨, 스킵")
                return
            }
            
            hasLoadedData = true
            
            Task {
                // 병렬로 데이터 로드
                async let projectDetail: () = viewModel.fetchProjectDetail()
                async let questionList: () = viewModel.fetchQuestionList()
                
                await projectDetail
                await questionList
            }
        }
    }
}
```

 `.onAppear`를 사용한 이유
- `.task`: View 재생성 시 자동 취소/재시작 → cancelled 에러 발생
- `.onAppear`: View가 처음 나타날 때만 실행 → `hasLoadedData` 플래그로 중복 방지
- rootScreen 변경 + path 초기화로 View가 2번 생성되는 상황에서 안정적

### `HomeViewModel`
프로젝트 목록 조회 및 날짜 포맷팅
```swift
@MainActor
class HomeViewModel: ObservableObject {
    @Published var projects: [ProjectListItemResponse] = []
    
    func fetchProjects() async {
        do {
            projects = try await projectRepository.getProjectList(skip: 0, limit: 100)
        } catch {
            errorMessage = "프로젝트 목록을 불러올 수 없습니다."
        }
    }
}

// String Extension으로 날짜 포맷팅
extension String {
    func toDateString(format: String = "yyyy.MM.dd") -> String {
        guard let date = self.toDate() else { return self }
        return date.toString(format: format)
    }
}
```

### `ProjectListView`
프로젝트 목록 UI 및 Workspace 진입
```swift
struct ProjectCardCell: View {
    @EnvironmentObject var appState: AppState
    let project: ProjectListItemResponse
    
    var body: some View {
        HStack {
            // UI
        }
        .contentShape(Rectangle())
        .onTapGesture {
            //  MainTabView의 fullScreenCover로 Workspace 진입
            appState.openWorkspace(projectId: project.id)
        }
    }
}

// AppState에서 관리
@Published var selectedProjectId: String?

func openWorkspace(projectId: String) {
    selectedProjectId = projectId
}

// MainTabView
.fullScreenCover(item: $appState.selectedProjectId) { projectId in
    CoverLetterWorkspaceView(
        projectId: projectId,
        questions: []  // HomeView에서는 빈 배열, Workspace에서 API 조회
    )
}
```

### 네트워크 레이어
```swift
// Repository 패턴
protocol ProjectRepository {
    func createProject(request: CreateProjectRequest) async throws -> ProjectResponse
    func getProjectList(skip: Int, limit: Int) async throws -> [ProjectListItemResponse]
    func getProjectDetail(projectId: String) async throws -> ProjectDetailResponse
}

// DTO
struct CreateProjectRequest: Encodable {
    let company: String
    let companyTalent: String
    let jobPosition: String
    let questions: [QuestionRequest]  // 프로젝트 생성 시 문항 포함
    let recruitNotice: String
}

struct QuestionResponse: Decodable {
    let id: String
    let question: String
    let maxLength: Int?  // null 가능
    let answer: String?
}
```
## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
- Resolved: #37 
-  Resolved: #38 